### PR TITLE
Installer now tries to set permissions

### DIFF
--- a/installer/controllers/installer.php
+++ b/installer/controllers/installer.php
@@ -249,11 +249,13 @@ class Installer extends Controller
 		// Get the write permissions for the folders
 		foreach($this->writeable_directories as $dir)
 		{
+			@chmod("../$dir", 0777);
 			$permissions['directories'][$dir] = is_really_writable('../' . $dir);
 		}
 		
 		foreach($this->writeable_files as $file)
 		{
+			@chmod("../$file", 0666);
 			$permissions['files'][$file] = is_really_writable('../' . $file);
 		}
 		


### PR DESCRIPTION
Installer now tries to set permissions correctly before checking. Will give a warning on any UNIX based system if the webserver does not have permission to do this action which we suppress using the @ command.

This should help the not UNIX savvy...
