### PR TITLE
Fixed a bug

### DIFF
--- a/system/pyrocms/modules/pages/views/admin/form.php
+++ b/system/pyrocms/modules/pages/views/admin/form.php
@@ -33,9 +33,9 @@
 						<label for="slug"><?php echo lang('pages.slug_label');?></label>
 
 						<?php if(!empty($page->parent_id)): ?>
-							<?php echo site_url().$parent_page->path; ?>/
+							<?php echo site_url($parent_page->path); ?>/
 						<?php else: ?>
-							<?php echo site_url(); ?>
+							<?php echo ( ! empty($this->config->config->index_page)) ? site_url().'/' : site_url(); ?>
 						<?php endif; ?>
 
 						<?php if($this->uri->segment(3,'') == 'edit'): ?>


### PR DESCRIPTION
When config['index_page'] isset, the url generated as preview would miss a slash i.e. http://pyrocms.com/index.phpfirstslug/secondslug instead of http://pyrocms.com/index.php/firstslug/secondslug
