### PR TITLE
Error on navigation creation

### DIFF
--- a/system/pyrocms/modules/navigation/controllers/admin.php
+++ b/system/pyrocms/modules/navigation/controllers/admin.php
@@ -24,7 +24,7 @@ class Admin extends Admin_Controller
 		array(
 			'field' => 'link_type',
 			'label'	=> 'lang:nav_type_label',
-			'rules'	=> 'trim|alpha'
+			'rules'	=> 'trim|required|alpha'
 		),
 		array(
 			'field' => 'url',


### PR DESCRIPTION
If you try to create a new navigation link and enter a Title value but do not select a Link type and try and save it will throw a php notice and end with a database error. My fix is code but maybe a database schema tweek would be better.

A PHP Error was encountered
Severity: Notice
Message: Undefined index: link_type
Filename: models/navigation_m.php
Line Number: 106
A PHP Error was encountered
Severity: Warning
Message: Cannot modify header information - headers already sent by (output started at /Applications/MAMP/htdocs/pyrocms/system/codeigniter/core/Exceptions.php:171)
Filename: core/Common.php
Line Number: 428
A Database Error Occurred
Error Number: 1048
Column 'link_type' cannot be null
INSERT INTO navigation_links (title, link_type, url, uri, module_name, page_id, position, target, class, navigation_group_id) VALUES ('Test', NULL, 'http://', '', '0', 0, 6, '_self', '', 1)
Filename: /Applications/MAMP/htdocs/pyrocms/modules/navigation/models/navigation_m.php
Line Number: 115

First ever 'pull' actually first ever time using git, be kind! lol. Thought this would be quicker/more productive than creating a new issue or forum post. More to come, hopefully!
