### PR TITLE
Make it so you can configure the location of SimplePie's cache dir. 

### DIFF
--- a/addons/widgets/twitter_feed/twitter_feed.php
+++ b/addons/widgets/twitter_feed/twitter_feed.php
@@ -31,7 +31,7 @@ class Widget_Twitter_feed extends Widgets
 	public function run($options)
 	{
 		$this->load->library('simplepie');
-		$this->simplepie->set_cache_location(APPPATH . 'cache/simplepie/');
+		$this->simplepie->set_cache_location($this->config->item('simplepie_cache_dir'));
 		$this->simplepie->set_feed_url('http://twitter.com/statuses/user_timeline/'.$options['username'].'.rss');
 		$this->simplepie->init();
 

--- a/system/pyrocms/config/cache.php
+++ b/system/pyrocms/config/cache.php
@@ -7,3 +7,6 @@ $config['cache_default_expires'] = 0;
 // Will soon make these options into settings items
 $config['navigation_cache'] = 21600; // 6 hours
 $config['rss_cache'] = 3600; // 1 hour
+
+// Set the location for simplepie cache
+$config['simplepie_cache_dir'] = APPPATH . 'cache/simplepie/';

--- a/system/pyrocms/controllers/admin.php
+++ b/system/pyrocms/controllers/admin.php
@@ -128,7 +128,7 @@ class Admin extends Admin_Controller
 
 		// Dashboard RSS feed (using SimplePie)
 		$this->load->library('simplepie');
-		$this->simplepie->set_cache_location(APPPATH . 'cache/simplepie/');
+		$this->simplepie->set_cache_location($this->config->item('simplepie_cache_dir'));
 		$this->simplepie->set_feed_url($this->settings->dashboard_rss);
 		$this->simplepie->init();
 		$this->simplepie->handle_content_type();

--- a/system/pyrocms/widgets/rss_feed/rss_feed.php
+++ b/system/pyrocms/widgets/rss_feed/rss_feed.php
@@ -31,7 +31,7 @@ class Widget_Rss_feed extends Widgets
 	public function run($options)
 	{
 		$this->load->library('simplepie');
-		$this->simplepie->set_cache_location(APPPATH . 'cache/simplepie/');
+		$this->simplepie->set_cache_location($this->config->item('simplepie_cache_dir'));
 		$this->simplepie->set_feed_url( $options['feed_url'] );
 		$this->simplepie->init();
 		


### PR DESCRIPTION
Currently SimplePie's cache dir was hard coded in. This commit makes it so you can configure the cache dir from cache.php. A a matter of practice I try to keep all my caches out of the document root and out of the code base.  
