### PR TITLE
Saving Page Layouts as Files

### DIFF
--- a/system/pyrocms/modules/pages/language/english/page_layouts_lang.php
+++ b/system/pyrocms/modules/pages/language/english/page_layouts_lang.php
@@ -29,6 +29,8 @@ $lang['page_layouts.delete_success']                 = 'Page layout #%s has been
 $lang['page_layouts.mass_delete_success']            = '%s page layouts have been deleted.';
 $lang['page_layouts.delete_none_notice']             = 'No page layouts were deleted.';
 $lang['page_layouts.already_exist_error']            = 'A page layout with the slug "%s" already exists.';
+$lang['page_layouts.layout_file_save_error']		 = 'Unable to save page layout as file. Please check the path and make sure it\'s writable.';
+$lang['page_layouts.sync_success']					 = 'Layouts successfully synced.';
 
 $lang['page_layouts.variable_introduction']          = 'In this input box there are two variables available';
 $lang['page_layouts.variable_title']                 = 'Contains the title of the page.';

--- a/system/pyrocms/modules/pages/models/page_layouts_m.php
+++ b/system/pyrocms/modules/pages/models/page_layouts_m.php
@@ -10,7 +10,6 @@
  */
 class Page_layouts_m extends MY_Model
 {
-	
     /**
      * Create a new page layout
 	 * 
@@ -27,6 +26,8 @@ class Page_layouts_m extends MY_Model
         
         return parent::insert($input);
     }
+
+	// --------------------------------------------------------------------------
     
     /**
      * Update a page layout
@@ -43,4 +44,120 @@ class Page_layouts_m extends MY_Model
         
         return parent::update($id, $input);
     }
+
+	// --------------------------------------------------------------------------
+    
+    /**
+     * Save 
+	 * 
+	 * @access 	public
+	 * @param 	string
+	 * @return mixed
+     */
+    public function save_layout_file( $id, $title, $body )
+    {
+		$path = ADDONPATH . 'layouts';
+
+        if( is_dir($path) ):
+     		
+     		$this->load->helper( array('file', 'url') );   
+        	
+        	$file_name = $id . '_' . url_title( $title, 'underscore', TRUE ) . '.html';
+        	
+        	if( write_file( $path . '/' . $file_name, $body, FOPEN_WRITE_CREATE_DESTRUCTIVE ) ):
+        	
+        		@chmod( $path . '/' . $file_name, FILE_WRITE_MODE ); 
+        	
+        	else:
+        	
+        		return FALSE;
+        	
+        	endif;
+        
+        endif;
+        
+        return TRUE;
+	}
+
+	// --------------------------------------------------------------------------
+
+	/**
+	 * Get a layout
+	 *
+	 * @access	public
+	 * @param	int
+	 * @access	obj
+	 */	
+	public function get( $id )
+	{
+		$path = ADDONPATH . 'layouts/';
+	
+		$this->load->helper('file');
+	
+		$this->db->limit(1)->where('id', $id);
+		$db_obj = $this->db->get('page_layouts');
+		
+		$layout = $db_obj->row();
+		
+		// Get layout file and replace the body
+		if( $this->settings->get('enable_layout_files') == '1' ):
+		
+	    	$file_name = $path . '/' . $id . '_' . url_title( $layout->title, 'underscore', TRUE ) . '.html';
+	    
+	        if( file_exists( $file_name ) ):
+	        
+	        	$layout->body = read_file( $file_name );
+	        	
+	        endif;
+	        
+	    endif;
+				
+		return $layout;
+	}
+
+	// --------------------------------------------------------------------------
+	
+	/**
+	 * Delete layout file
+	 *
+	 * @access	public
+	 * @param	int
+	 * @return	void
+	 */
+	public function delete_layout_file( $id )
+	{
+		$this->db->limit(1)->where('id', $id);
+		$db_obj = $this->db->get('page_layouts');
+		
+		$layout = $db_obj->row();
+
+		@unlink( ADDONPATH . 'layouts/' . $id . '_' . url_title( $layout->title, 'underscore', TRUE ) . '.html' );
+	}
+
+	// --------------------------------------------------------------------------
+	
+	/**
+	 * Sync Layouts to Database
+	 *
+	 * @access	public
+	 * @param	array
+	 * @return	void
+	 */
+	public function sync_layouts( $ids )
+	{
+		// Run through each ID, grab the layout data from the 
+		// file and save it back to the DB
+			
+		foreach( $ids as $layout_id ):
+		
+			$layout = $this->get( $layout_id );
+			
+			$update_data['body'] = $layout->body;
+			
+			$this->db->where('id', $layout_id);
+			$this->db->update('page_layouts', $update_data);
+		
+		endforeach;
+	}
+
 }

--- a/system/pyrocms/modules/pages/views/admin/layouts/index.php
+++ b/system/pyrocms/modules/pages/views/admin/layouts/index.php
@@ -1,7 +1,7 @@
 
 	<h3><?php echo lang('page_layouts.list_title'); ?></h3>
 		
-		<?php echo form_open('admin/pages/layouts/delete');?>
+		<?php echo form_open('admin/pages/layouts/action');?>
 	
 			<?php if (!empty($page_layouts)): ?>
 				<table border="0" class="table-list">		    
@@ -31,7 +31,11 @@
 			<?php endif; ?>		
 			
 			<div class="float-right">
-								
+			
+				<?php if( $this->settings->get('enable_layout_files') == '1' ): ?>
+				<button type="submit" name="btnAction" value="sync" class="button confirm"><span>Sync</span></button>
+				<?php endif; ?>
+				
 				<?php $this->load->view('admin/partials/buttons', array('buttons' => array('delete') )); ?>
 			</div>
 	


### PR DESCRIPTION
These are some changes I made to allow page layouts to be saved as files. I do a lot of work in the page layouts and go tired of editing them in the editor. This implementation is very simple:
- If you have it enabled, it always saves layout files in a folder named "layouts" in the add-ons folder that you need to create and set to be writable.
- You can sync the files and database files using a simple interface that mirrors the delete functionality.

You need a setting named 'enable_layout_files' set to '1' for it to work, but I'm not sure how to get that to be added via an update routine. I added in the update routine into the Settings module details, but there doesn't seem to be a way to update the native modules  like third party modules.
