### PR TITLE
Admin Navigation menu to allow for no-submenu links

### DIFF
--- a/system/pyrocms/views/admin/partials/navigation.php
+++ b/system/pyrocms/views/admin/partials/navigation.php
@@ -1,68 +1,73 @@
 <nav id="main-nav">
-
 	<ul>
 		<li><?php echo anchor('admin', lang('cp_admin_home_title'), 'class="top-link no-submenu' . (!$this->module > '' ? ' current' : '').'"');?></li>
 		
-        
-        <?php
-		
-		foreach($menu_items as $menu_item){
+		<?php
+		foreach($menu_items as $menu_item)
+		{
 			
-			$display = '';
+			$count = 0;
 			
-			foreach($modules[$menu_item] as $module){
-				
-				if(in_array($module['slug'], $this->permissions) OR $this->user->group == 'admin'){
-					
-					$display = 1;
-				
+			//Let's see how many menu items they have access to
+			if($this->user->group == 'admin')
+			{
+				$count = count($modules[$menu_item]);
+			}
+			else
+			{
+				foreach($modules[$menu_item] as $module)
+				{
+					$count += in_array($module['slug'], $this->permissions) ? 1 : 0;
 				}
-				
+			}
+			
+			if($menu_item == 'users')
+			{ // If we are in the users menu, we have to account for the hacked link below
+				$count += (in_array('users', $this->permissions) OR $this->user->group == 'admin') ? 1 : 0;
 			}
 				
-			if($display === 1){
+			if($count > 0){
 				
-				?>
-				
-				<li><a href="#" class="top-link <?php echo ($this->module_details AND $this->module_details['menu'] == $menu_item) ? 'current' : ''; ?>">
+				// If they only have access to one item in this menu, why not just have it as the main link?
+				if($count > 1)
+				{ // They have access to more than one menu item, so create a drop menu
+			?>
+					<li>
+					<?php
+						$name = lang('cp_nav_'.$menu_item)!=''&&lang('cp_nav_'.$menu_item)!=NULL ? lang('cp_nav_'.$menu_item) : $menu_item;
+						$current = $this->module_details && $this->module_details['menu'] == $menu_item;
+						$class = $current ? "top-link current" : "top-link";
+						echo anchor('#', $name, array('class' => $class));
+					?>
+	                    <ul>
+				<? }?>
 				<?php
-				
-					if(lang('cp_nav_'.$menu_item)!=''&&lang('cp_nav_'.$menu_item)!=NULL){
-						echo lang('cp_nav_'.$menu_item);	
-					}
-					else{
-						echo $menu_item;
-					}				
-				?>
-                </a>
-                    <ul>
-                    <?php
-                    
-					if( (in_array('users', $this->permissions) OR $this->user->group == 'admin') && $menu_item == 'users'): ?>
-                    
-						<li><?php echo anchor('admin/users', lang('cp_manage_users'), array('style' => 'font-weight: bold;', 'class' => $module == 'modules' ? 'current' : ''));?></li>
-                        
-					<?php endif;
-					
-                    ksort($modules[$menu_item]);
-                    foreach ($modules[$menu_item] as $module){
-                        
-                        if(in_array($module['slug'], $this->permissions) OR $this->user->group == 'admin'){
-                        
-                            if(lang('cp_nav_'.$module['name'])!=''&&lang('cp_nav_'.$module['name'])!=NULL){
-                                $module['name'] = lang('cp_manage_'.$module['slug']);	
-                            }
-                            ?>
-                            <li><?php echo anchor('admin/'.$module['slug'], $module['name'], ($this->module == $module['slug']) ? 'class="current"' : '');?></li>                                         
-                        <?php
-                        
-                        }					
-                    }
-                    
-                    ?>
-                    </ul>
-                </li>
-                <?php
+						// Not a big fan of the following hack, if a module needs two navigation links, we should be able to define that
+						if( (in_array('users', $this->permissions) OR $this->user->group == 'admin') && $menu_item == 'users'): ?>
+							<li><?php echo anchor('admin/users', lang('cp_manage_users'), array('style' => 'font-weight: bold;', 'class' => $module == 'modules' ? 'current' : ''));?></li>
+						<?php endif;?>
+						
+						<?php //Lets get the sub-menu links, or parent link if that is the case
+						ksort($modules[$menu_item]);
+						foreach ($modules[$menu_item] as $module){
+							if(lang('cp_nav_'.$module['name'])!=''&&lang('cp_nav_'.$module['name'])!=NULL){
+								$module['name'] = lang('cp_manage_'.$module['name']);	
+							}
+							$current = $this->module == $module['slug'];
+							$class = $current ? "current " : "";
+							$class .= $count <= 1 ? "top-link no-submenu " : "";
+							if(in_array($module['slug'], $this->permissions) OR $this->user->group == 'admin')
+							{?>
+								<li><?php echo anchor('admin/'.$module['slug'], $module['name'], array('class'=>$class));?></li>                                         
+							<?php
+							}
+						}?>
+				<?php if($count > 1)
+				{ // They have access to more than one menu item, so close the drop menu?>
+	                    </ul>
+	                </li>
+				<?php }?>
+			<?php
 			}
 		}
 		


### PR DESCRIPTION
Seems a bit pointless to have drop down sub-menu's for navigation groups with only one menu item. This admin navigation partial now checks for how many menu items the current user has access to and if only one, simply display it as the top level link.

The only question is should the link title be the original links title (ie. the module name) or should it use the menu title?

Also saw what looks like a bug in there:
<code>
if(lang('cp_nav_'.$module['name'])!=''&&lang('cp_nav_'.$module['name'])!=NULL){
    $module['name'] = lang('cp_manage_'.$module['slug']);  
}
</code>
Changed "slug" above to "name".
