### PR TITLE
Pages routing fix

### DIFF
--- a/system/pyrocms/modules/pages/controllers/pages.php
+++ b/system/pyrocms/modules/pages/controllers/pages.php
@@ -40,7 +40,7 @@ class Pages extends Public_Controller
     	// This page has been routed to with pages/view/whatever
     	if ($this->uri->rsegment(1, '').'/'.$method == 'pages/view')
     	{
-    		$url_segments = $this->uri->total_rsegments() > 0 ? array_slice($url_segments, $this->uri->rsegment_array(), 2) : null;
+    		$url_segments = $this->uri->total_rsegments() > 0 ? array_slice($this->uri->rsegment_array(), 2) : null;
     	}
     	
     	// not routed, so use the actual URI segments


### PR DESCRIPTION
Fixing a bug described here:

http://blog.adamfairholm.com/dynamic-pages-with-pyrocms-and-pyrostreams/

Restores the ability to route pages to the pages module.
