### PR TITLE
Updated basic admin login dialog

### DIFF
--- a/system/cms/themes/admin_theme/css/admin/style.css
+++ b/system/cms/themes/admin_theme/css/admin/style.css
@@ -497,9 +497,11 @@ body#login #login-box label.remember {
 body#login #login-box input.remember {
 	display: inline;
 	width: 20px;
-	height: 20px;
+	height: 14px;
 	padding: 0;
 	margin: 0;
+	border: 0px;
+	outline: 0px;
 }
 body#login #login-box input {
 	background-color: #eaedf2;


### PR DESCRIPTION
The basic admin login has a outline on the checkbox and the label didn't line up.

I fixed both.
