### PR TITLE
Feature/frontend language dropdown

### DIFF
--- a/system/cms/modules/users/controllers/users.php
+++ b/system/cms/modules/users/controllers/users.php
@@ -697,15 +697,15 @@ class Users extends Public_Controller
 	    // get the languages offered on the front-end
 	    $site_public_lang = explode(',', Settings::get('site_public_lang'));
 	    
-	   foreach ($this->config->item('supported_languages') as $lang_code => $lang)
-	   {
-	   	// if the supported language is offered on the front-end
-			if (in_array($lang_code, $site_public_lang))
-			{
-				// add it to the dropdown list
-				$languages[$lang_code] = $lang['name'];
-			}
-		}
+	    foreach ($this->config->item('supported_languages') as $lang_code => $lang)
+	    {
+	       // if the supported language is offered on the front-end
+	       if (in_array($lang_code, $site_public_lang))
+	       {
+          	// add it to the dropdown list
+        	   $languages[$lang_code] = $lang['name'];
+	       }
+	    }
 
 		// Render the view
 		$this->template->build('profile/edit', array(


### PR DESCRIPTION
Only show supported languages that are offered (in back-end setings) in the front-end drop-down.
