### PR TITLE
Fixing custom page routing error

### DIFF
--- a/system/cms/modules/pages/controllers/pages.php
+++ b/system/cms/modules/pages/controllers/pages.php
@@ -39,7 +39,7 @@ class Pages extends Public_Controller
 		// This page has been routed to with pages/view/whatever
 		if ($this->uri->rsegment(1, '').'/'.$method == 'pages/view')
 		{
-			$url_segments = $this->uri->total_rsegments() > 0 ? array_slice($url_segments, $this->uri->rsegment_array(), 2) : null;
+			$url_segments = $this->uri->total_rsegments() > 0 ? array_slice($this->uri->rsegment_array(), 2) : null;
 		}
 		
 		// not routed, so use the actual URI segments


### PR DESCRIPTION
In the pages module controller, array_slice was given the rsegment_array as the second field which
should be the offset.

Removing the first parameter allows users to set custom routing using pages/view/something.
