### PR TITLE
Fix broken Arabic titles

### DIFF
--- a/system/cms/themes/default/theme.php
+++ b/system/cms/themes/default/theme.php
@@ -45,6 +45,8 @@ class Theme_Default extends Theme {
 				$cufon_enabled	= FALSE;
 				break;
 			case 'ar':
+				$cufon_enabled = FALSE;
+				break;
 			case 'he':
 				$cufon_enabled	= TRUE;
 			case 'ru':


### PR DESCRIPTION
Disable Cufon to fix the display of broken Arabic titles
