### PR TITLE
Feature/template module details info

### DIFF
--- a/system/cms/modules/templates/details.php
+++ b/system/cms/modules/templates/details.php
@@ -19,7 +19,7 @@ class Module_Templates extends Module {
 			'name' => array(
 				'sl' => 'Email predloge',
 				'en' => 'Email Templates',
-				'nl' => 'Emailsjablonen',
+				'nl' => 'Email sjablonen',
 				'es' => 'Plantillas de email',
 				'ar' => 'قوالب الرسائل الإلكترونية',
 				'br' => 'Modelos de e-mail',


### PR DESCRIPTION
causes the first 'en' key to be ignored and we get the dutch translation for english.  also modified the dutch translation to read 'email sjablonen'.
