### PR TITLE
Fixed top navigation menu item width issues

### DIFF
--- a/system/cms/themes/pyrocms/css/workless.css
+++ b/system/cms/themes/pyrocms/css/workless.css
@@ -1011,9 +1011,9 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 }
 
 .topbar ul li {
-  width: 80px;
   float: left;
   font-size: 13px;
+  position: relative;
 }
 
 .topbar ul li a {
@@ -1066,8 +1066,8 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   background-color: #333;
   float: left;
   display: none;
-  position: relative;
-  top: 1px;
+  position: absolute;
+  top: 50px;
   min-width: 160px;
   max-width: 220px;
   _width: 160px;


### PR DESCRIPTION
The horizontal top navigation has been a bit troublesome, especially with some languages having long words for menu items. By removing the fixed width on the top `<li>` elements, the menu items can stretch/shrink which prevents them from spilling onto 2-3 lines.

I have absolutely positioned the sub-menus so that the top menu items don't need to stretch to accommodate them. This means that the sub-menus are often wider than the top-level items which does look a little strange, but I think that's better than stretching the top-level items.
