### PR TITLE
Changed order of is_object() and is_array() since  will always be an arra

### DIFF
--- a/system/cms/libraries/Tags.php
+++ b/system/cms/libraries/Tags.php
@@ -846,11 +846,6 @@ class Tags {
 	 */
 	private function _force_array($var, $level = 0)
 	{
-		if (is_object($var))
-		{
-			$var = (array) $var;
-		}
-
 		if (is_array($var))
 		{
 			// Make sure everything else is array or single value
@@ -861,6 +856,11 @@ class Tags {
 					$child = $this->_force_array($child, $level + 1);
 				}
 			}
+		}
+		
+		if (is_object($var))
+		{
+			$var = (array) $var;
 		}
 
 		return $var;


### PR DESCRIPTION
Changed order of is_object() and is_array() since  will always be an array after is_object() is run and therefor will seem to eat all memory
