### PR TITLE
translated marked lines in modules/templates/language/german/templates_lang.php

### DIFF
--- a/system/cms/modules/templates/language/german/templates_lang.php
+++ b/system/cms/modules/templates/language/german/templates_lang.php
@@ -1,32 +1,32 @@
 <?php defined('BASEPATH') or exit('No direct script access allowed');
 
 // Labels
-$lang['templates.language_label']			= 'Language'; #translate
-$lang['templates.choose_lang_label']		= 'Choose language'; #translate
-$lang['templates.subject_label']			= 'Subject'; #translate
-$lang['templates.body_label']				= 'Body'; #translate
+$lang['templates.language_label']			= 'Sprache'; 
+$lang['templates.choose_lang_label']		= 'Sprache wählen'; 
+$lang['templates.subject_label']			= 'Betreff'; 
+$lang['templates.body_label']				= 'Inhalt'; 
 $lang['templates.slug_label']				= 'Slug'; #translate
 
 // Titles
-$lang['templates.create_title']				= 'Create template'; #translate
-$lang['templates.edit_title']				= 'Editing template "%s"'; #translate
-$lang['templates.clone_title']				= 'Coping template "%s"'; #translate
-$lang['templates.list_title']				= 'List templates'; #translate
-$lang['templates.default_title']			= 'Default templates'; #translate
-$lang['templates.user_defined_title']		= 'User defined templates'; #translate
+$lang['templates.create_title']				= 'Template erstellen'; 
+$lang['templates.edit_title']				= 'Template "%s" bearbeiten'; 
+$lang['templates.clone_title']				= 'Template "%s" kopieren'; 
+$lang['templates.list_title']				= 'Templates auflisten'; 
+$lang['templates.default_title']			= 'Standard Templates';
+$lang['templates.user_defined_title']		= 'Benutzerdefinierte Templates'; 
 
 // Messages
-$lang['templates.tmpl_create_success']		= 'Email template "%s" has been saved.'; #translate
-$lang['templates.tmpl_create_error']		= 'Email template "%s" was not saved.'; #translate
-$lang['templates.tmpl_edit_success']		= 'Changes made to email template "%s" has been saved.'; #translate
-$lang['templates.tmpl_edit_error']			= 'Changes made to email template "%s" was not saved.'; #translate
-$lang['templates.tmpl_clone_success']		= '"%s" has been cloned. You may now edit the template to your liking.'; #translate
-$lang['templates.tmpl_clone_error']			= '"%s" was unable to be cloned.  Please try again.'; #translate
-$lang['templates.single_delete_success']	= 'The email template has been deleted.'; #translate
-$lang['templates.mass_delete_success']		= '%s email templates out of %s successfully deleted.'; #translate
-$lang['templates.mass_delete_error'] 		= 'Error occurred while trying to delete email template "%s".'; #translate
-$lang['templates.default_delete_error'] 	= 'Error occurred, default email templates can not be removed.'; #translate
-$lang['templates.no_select_error'] 			= 'You need to select email templates first.'; #translate
-$lang['templates.already_exist_error']		= 'A email template with the name "%s" already exists.'; #translate
+$lang['templates.tmpl_create_success']		= 'Email Template "%s" wurde gespeichert.';
+$lang['templates.tmpl_create_error']		= 'Email Template "%s" wurde nicht gespeichert.';
+$lang['templates.tmpl_edit_success']		= 'Änderungen an Email-Template "%s" wurden gespeichert.';
+$lang['templates.tmpl_edit_error']			= 'Änderungen an Email-Template "%s" wurden nicht gespeichert.';
+$lang['templates.tmpl_clone_success']		= '"%s" wurde dupliziert. Das Template kann jetzt nach Deinen Wünschen bearbeitet werden.';
+$lang['templates.tmpl_clone_error']			= '"%s" konnte nicht dupliziert werden.  Bitte versuch es noch einaml.'; 
+$lang['templates.single_delete_success']	= 'Das Email-Template wurde gelöscht.';
+$lang['templates.mass_delete_success']		= '%s Email-Templates von %s wurden erfolgreich gelöscht.';
+$lang['templates.mass_delete_error'] 		= 'Fehler beim Löschen des Email-Templates "%s".';
+$lang['templates.default_delete_error'] 	= 'Fehler! Standard Email-Templates können nicht gelöscht werden.';
+$lang['templates.no_select_error'] 			= 'Es muss zuerst ein Email-Template ausgewählt werden.';
+$lang['templates.already_exist_error']		= 'Ein Email-Template mit dem Namen "%s" existiert bereits.';
 
 /* End of file templates_lang.php */


### PR DESCRIPTION
I'm not sure if there is a proper translation for the word "slug" in german. The closest would be "Rohling" which means "raw piece", but nobody says that.
