### PR TITLE
Cancel/close buttons use active section URI if it is set

### DIFF
--- a/system/cms/themes/pyrocms/views/admin/partials/buttons.php
+++ b/system/cms/themes/pyrocms/views/admin/partials/buttons.php
@@ -54,7 +54,7 @@
 			case 'preview':
 				if($btn_class == 'btn') $btn_class .= ' gray';
 				$uri = 'admin/' . $this->module_details['slug'];
-				$active_section = $this->_ci_cached_vars['active_section'];
+				$active_section = $this->load->get_var('active_section');
 
 				if ($active_section && isset($this->module_details['sections'][$active_section]['uri']))
 				{


### PR DESCRIPTION
Changes the URI of the cancel/close/preview(?) buttons to be the index of the current section, rather than the index of the module. For example if you're in admin/blog/categories/create, the button takes you to admin/blog/categories/index instead of admin/blog.

I'm not sure if using `_ci_cached_vars` is good practice, but I couldn't find any other way of retrieving the active section.
