### PR TITLE
Added additional check for $active url

### DIFF
--- a/system/cms/modules/navigation/plugin.php
+++ b/system/cms/modules/navigation/plugin.php
@@ -42,6 +42,7 @@ class Plugin_Navigation extends Plugin
 		$separator		= $this->attribute('separator', '');
 															//deprecated
 		$link_class		= $this->attribute('link-class', $this->attribute('link_class', ''));
+		$match_segment		= $this->attribute('match_segment', null);
 															//deprecated
 		$more_class		= $this->attribute('more-class', $this->attribute('more_class', ''));
 		$current_class	= $this->attribute('class', 'current');
@@ -149,7 +150,21 @@ class Plugin_Navigation extends Plugin
 				{
 					$wrapper['class'][] = 'has_' . $current_class;
 				}
-
+				elseif ($match_segment)
+				{
+					$match_segment_string = '';
+					for ($i = 1; $i <= $match_segment; $i++) {
+						$match_segment_string .= $this->uri->segment($i).DIRECTORY_SEPARATOR;
+					}
+	
+					$match_segment_string = substr($match_segment_string, 0, -1);
+	
+					if ($link['url'] === site_url().$match_segment_string)
+					{
+						$is_current = TRUE;
+						$wrapper['class'][] = $current_class;
+					}
+				}
 				if ($level === 0)
 				{
 					// we've got the expected result, stop check if has current children


### PR DESCRIPTION
for example you have navigation having:
home => /
news => /news

So when you're at home - you will get home active
when you are at /news - you will have news active

with this commit you'll be able to add: match_segment = 1 for example, which will allow you to give active class while you are in:
/news/title-1 
/news/category/title-1 
/news/category/subcategory/title-1 

all this will be marked as 'active' so you'll get active class in your navigation.

If you will add match_segment=2, first two segment should have to match...

I think you got an idea.

P.S.
I think that 
$match_segment      = $this->attribute('match_segment', null);
can be set to 1 easily by default. since probably 90% of people will need this as default.. (not sure) 

Waiting for comments :) 
