### PR TITLE
Permissions: allow restrictions and subpermission arrays based on specified db table. User helper allows restrictions and subpermissions.

### DIFF
--- a/system/cms/modules/permissions/controllers/admin.php
+++ b/system/cms/modules/permissions/controllers/admin.php
@@ -53,17 +53,10 @@ class Admin extends Admin_Controller
 		}
 
 		$group = $this->group_m->get($group_id);
-		$edit_permissions = $this->permission_m->get_group($group_id);
-		$permisison_modules = $this->module_m->get_all(array('is_backend' => TRUE));
-
-		foreach ($permisison_modules as &$module)
-		{
-			$module['roles'] = $this->module_m->roles($module['slug']);
-		}
+		$permission_modules = $this->permission_m->get_modules($group_id);
 
 		$this->template
-			->set('edit_permissions', $edit_permissions)
-			->set('permisison_modules', $permisison_modules)
+			->set('permission_modules', $permission_modules)
 			->set('group', $group)
 			->build('admin/group', $this->data);
 	}

--- a/system/cms/modules/permissions/views/admin/group.php
+++ b/system/cms/modules/permissions/views/admin/group.php
@@ -15,23 +15,44 @@
 		</thead>
 		<tbody>
 	
-		<?php foreach ($permisison_modules as $module): ?>
-			<tr>
-				<td style="width: 30px"><?php echo form_checkbox('modules[' . $module['slug'] . ']', TRUE, array_key_exists($module['slug'], $edit_permissions), 'id="'.$module['slug'].'"'); ?></td>
-				<td>
-					<label class="inline" for="<?php echo $module['slug']; ?>"><?php echo $module['name']; ?></label>
-				</td>
-				<td>
-					<?php if ( ! empty($module['roles'])): ?>
-						<?php foreach ($module['roles'] as $role): ?>
-							<label class="inline"><?php echo form_checkbox('module_roles[' . $module['slug'] . ']['.$role.']', TRUE, isset($edit_permissions[$module['slug']]) AND array_key_exists($role, (array) $edit_permissions[$module['slug']])); ?>
-							 <?php echo lang($module['slug'].'.role_'.$role); ?></label>
+	<?php foreach ($permission_modules as $module): ?>
+		<tr>
+			<td style="width: 30px">
+				<?php echo form_checkbox('modules[' . $module['slug'] . ']', TRUE, $module['checked'], 'id="'.$module['slug'].'"');?>
+			</td>
+			<td>
+				<label class="inline" for="<?php echo $module['slug']; ?>"><?php echo $module['name']; ?></label>
+			</td>
+			<td>
+				<?php foreach ($module['binary_roles'] as $rolename => $checked): ?>
+					<label class="inline">
+					<?php echo form_checkbox('module_roles[' . $module['slug'] . ']['.$rolename.']',TRUE, $checked);?> 
+					<?php echo lang($module['slug'].'.role_'.$rolename); ?>
+					</label>
+				<?php endforeach; ?>
+				
+				<?php foreach ($module['array_roles'] as $rolename => $subs): ?>
+					<?php 
+					//TODO: css input needed here
+					?>
+					<div style="border:1px solid #e4e4e4; padding:5px; margin-top:5px;">
+						<label style="margin-right:12px;">
+							<?php echo lang($module['slug'].'.role_'. $rolename)?> : 
+						</label>
+						<?php foreach ($subs as $subid => $sub): ?>
+							<label class="inline">
+							<?php echo form_checkbox('module_roles[' . $module['slug'] . ']['.$rolename .']['.$subid .']', TRUE, $sub['checked']); ?>
+							<?php echo $sub['name']; ?>
+							</label>
 						<?php endforeach; ?>
-					<?php endif; ?>
-				</td>
-			</tr>
-		<?php endforeach; ?>
-	
+
+					</div>				
+ 				<?php endforeach; ?>
+				
+			</td>
+		</tr>
+	<?php endforeach; ?>
+
 		</tbody>
 	</table>
 	

--- a/system/cms/modules/users/helpers/user_helper.php
+++ b/system/cms/modules/users/helpers/user_helper.php
@@ -11,10 +11,11 @@
 // ------------------------------------------------------------------------
 
 /**
- * Return a users display name based on settings
- *
- * @param int $user the users id
- * @return  string
+ * Return current users permission for a module role
+ * 
+ * @param string $module: module slug
+ * @param string $role: role name
+ * @return int 1/0 or array of subpermissions
  */
 function group_has_role($module, $role)
 {
@@ -25,17 +26,21 @@ function group_has_role($module, $role)
 
 	if (ci()->current_user->group == 'admin')
 	{
+		//if this is a restriction then admin doesn't need it
+		if (strpos($role, 'restrict') !== FALSE) return FALSE; 
+		
+		//else admin gets all permissions by default
 		return TRUE;
 	}
 
 	$permissions = ci()->permission_m->get_group(ci()->current_user->group_id);
 
-	if (empty($permissions[$module]) or empty($permissions[$module]->$role))
+	if (empty($permissions[$module]->$role))
 	{
 		return FALSE;
 	}
-
-	return TRUE;
+	//allow for array-type permissions return
+	return $permissions[$module]->$role;
 }
 
 


### PR DESCRIPTION
Permissions allows array of sub-permissions (based on a db table like categories). User helper modified to allow this and also to allow restrictions.

permission: default is true for admin else false
restriction: default is false for admin else true

Applied example: Blog permissions:
restrict to own posts only: restrict_own
restrict to selected categories : array( name=> 'restrict_categories', table=>'categories', field=>'title')

Will post separate commit and pull request with Blog changes that do just this.

Comments and discussion sought. Ta.
