### PR TITLE
added missing migration_lang file in codeigniter language for danish

### DIFF
--- a/system/codeigniter/language/danish/migration_lang.php
+++ b/system/codeigniter/language/danish/migration_lang.php
@@ -1,0 +1,13 @@
+<?php
+
+$lang['migration_none_found']			= "Ingen migrationer fundet.";
+$lang['migration_not_found']			= "Denne migration kunne ikke findes.";
+$lang['migration_multiple_version']		= "Der er flere migrationer for den samme version nummer: %d.";
+$lang['migration_class_doesnt_exist']	= "Migrationsklassen \"%s\" kunne ikke findes.";
+$lang['migration_missing_up_method']	= "Migrationsklassen \"%s\" mangler 'up' methoden.";
+$lang['migration_missing_down_method']	= "Migrationsklassen \"%s\" mangler 'up' methoden.";
+$lang['migration_invalid_filename']		= "Migrationen \"%s\" har et ugyldigt filnavn.";
+
+
+/* End of file migration_lang.php */
+/* Location: ./system/language/english/migration_lang.php */


### PR DESCRIPTION
the title says it. A migration_lang.php file was missing in the danish translation in the codeigniter language files, so I added it
