### PR TITLE
hide password by default on installer/complete

### DIFF
--- a/installer/views/complete.php
+++ b/installer/views/complete.php
@@ -10,7 +10,7 @@
 <p>
 	<strong>{email}:</strong> {user_email}<br><br>
 	
-	<strong>{password}:</strong> <span class="password">{user_password}</span> <a class="button show-pass" href="#">{show_password}</a>
+	<strong>{password}:</strong> <span class="password" style="display:none;">{user_password}</span> <a class="button show-pass" href="#">{show_password}</a>
 </p>
 
 <p>{outro_text}</p>


### PR DESCRIPTION
password is not hidden on the final (installer/complete) page of the installer. this remedies that. I prefer to add inline styles for hidden elements, you may prefer to add it via css.
