### PR TITLE
added missing semicolon in blog_lang.php

### DIFF
--- a/system/cms/config/config.php
+++ b/system/cms/config/config.php
@@ -26,7 +26,7 @@ $config['base_url']	= '';
 | variable so that it is blank.
 |
 */
-$config['index_page'] = 'index.php';
+$config['index_page'] = '';
 
 /*
 |--------------------------------------------------------------------------

--- a/system/cms/modules/blog/language/english/blog_lang.php
+++ b/system/cms/modules/blog/language/english/blog_lang.php
@@ -40,7 +40,7 @@ $lang['blog_archive_title']                 = 'Archive';
 $lang['blog_posts_title']					= 'Posts';
 $lang['blog_rss_posts_title']				= 'Blog posts for %s';
 $lang['blog_blog_title']					= 'Blog';
-$lang['blog_list_title']					= 'List Posts'
+$lang['blog_list_title']					= 'List Posts';
 
 // messages
 $lang['blog_no_posts']                    = 'There are no posts.';


### PR DESCRIPTION
fix for https://github.com/pyrocms/pyrocms/issues/928

just added a missing simicolon.  apologies if this pull request was incorrect.  totally new to git/github.  wasn't sure how to exclude the config from the commit as it was changed for me locally after initial clone...any tips would be appreciated :)
