### PR TITLE
Added html5shiv in order to allow IE render html5.

### DIFF
--- a/system/cms/themes/default/views/partials/metadata.html
+++ b/system/cms/themes/default/views/partials/metadata.html
@@ -13,6 +13,9 @@
 {{ theme:css file="style.css" }}
 <!-- End stylesheets -->
 
+<!-- Use Html5Shiv in order to allow IE render HTML5 -->
+<!--[if IE]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+
 <!-- Load jQuery Before Modules/Widgets -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6/jquery.min.js"></script>
 <script>window.jQuery || document.write("\x3Cscript src='{{ theme:js_url file='jquery/jquery.min.js' }}'>\x3C/script>")</script>


### PR DESCRIPTION
It seems that IE support is not being provided, but since I'm using pyroCMS for an enterprise project where IE is the standard, I'll be working on it. 

I added html5 support to IE through html5shiv. After that I'll start looking up some css bugs and quirks.
