### PR TITLE
English language keys were beign replaced by another language by mistake...

### DIFF
--- a/system/cms/widgets/navigation/navigation.php
+++ b/system/cms/widgets/navigation/navigation.php
@@ -19,7 +19,7 @@ class Widget_Navigation extends Widgets
 	);
 	public $description	= array(
 		'en' => 'Display a navigation group with a widget',
-		'en' => 'Προβάλετε μια ομάδα στοιχείων πλοήγησης στον ιστότοπο',
+		'el' => 'Προβάλετε μια ομάδα στοιχείων πλοήγησης στον ιστότοπο',
 		'nl' => 'Toon een navigatiegroep met een widget',
 		'br' => 'Exibe um grupo de links de navegação como widget em seu site',
 		'ru' => 'Отображает навигационную группу внутри виджета',

--- a/system/cms/widgets/social_bookmark/social_bookmark.php
+++ b/system/cms/widgets/social_bookmark/social_bookmark.php
@@ -12,14 +12,14 @@ class Widget_Social_bookmark extends Widgets
 {
 	public $title		= array(
 		'en' => 'Social Bookmark',
-		'en' => 'Κοινωνική δικτύωση',
+		'el' => 'Κοινωνική δικτύωση',
 		'nl' => 'Sociale Bladwijzers',
 		'br' => 'Social Bookmark',
 		'ru' => 'Социальные закладки',
 		);
 	public $description	= array(
 		'en' => 'Configurable social bookmark links from AddThis',
-		'en' => 'Παραμετροποιήσιμα στοιχεία κοινωνικής δικτυώσης από το AddThis',
+		'el' => 'Παραμετροποιήσιμα στοιχεία κοινωνικής δικτυώσης από το AddThis',
 		'nl' => 'Voeg sociale bladwijzers toe vanuit AddThis',
 		'br' => 'Adiciona links de redes sociais usando o AddThis, podendo fazer algumas configurações',
 		'ru' => 'Конфигурируемые социальные закладки с сайта AddThis',

--- a/system/cms/widgets/twitter_feed/twitter_feed.php
+++ b/system/cms/widgets/twitter_feed/twitter_feed.php
@@ -18,7 +18,7 @@ class Widget_Twitter_feed extends Widgets {
 	);
 	public $description	= array(
 		'en' => 'Display Twitter feeds on your website',
-		'en' => 'Προβολή των τελευταίων tweets από το Twitter',
+		'el' => 'Προβολή των τελευταίων tweets από το Twitter',
 		'nl' => 'Toon Twitterfeeds op uw website',
 		'br' => 'Mostra os últimos tweets de um usuário do Twitter no seu site.',
 		'ru' => 'Выводит ленту новостей Twitter на страницах вашего сайта',


### PR DESCRIPTION
... on some widgets. Fixed now.

Replaced the repeated "en" language keys by "el" where necessary.
