### PR TITLE
Fixed issue #948 - Clicking / editing navigation links works now.

### DIFF
--- a/system/cms/modules/navigation/js/navigation.js
+++ b/system/cms/modules/navigation/js/navigation.js
@@ -93,7 +93,7 @@
 		}).filter(':checked').change();
 
 		// show link details
-		$('#link-list li a').live('click', function()
+		$('#link-list li a').livequery('click', function()
 		{
 			var id = $(this).attr('rel');
 			link_id = $(this).attr('alt');


### PR DESCRIPTION
Seems that livequery() is more reliable than live() in this case.
- Tested in Firefox 8 Mac OS.
- Please verify that it works.
