### PR TITLE
Block Controller if restriction set in Navigation

### DIFF
--- a/system/cms/core/Public_Controller.php
+++ b/system/cms/core/Public_Controller.php
@@ -28,6 +28,16 @@ class Public_Controller extends MY_Controller
 			show_error($error, 503);
 		}
 
+		// check if this navigation menu is restricted
+		$this->load->model('navigation/navigation_m');
+		$restricted_m = $this->navigation_m->get_by(array('module_name'=>$this->module));
+		$restricted_to = (array) explode(',', $restricted_m->restricted_to);
+
+		if ($this->current_user->group != 'admin' && !empty($restricted_m->restricted_to) && !in_array($this->current_user->group_id, $restricted_to))
+		{
+			redirect('users/login/'.(empty($url_segments) ? '' : implode('/', $url_segments)));
+		}
+
 		// -- Navigation menu -----------------------------------
 		$this->load->model('pages/page_m');
 


### PR DESCRIPTION
If you set any restrictions in the Navigation Module they should be honored in the Public Controller.
The Navigation Module hides the menu but you can still access the page by it's url.
therefore what good are the Navigation Module Permissions if only to "hide" a menu?
