### PR TITLE
Add Text direction buttons to the advanced WYSIWYG

### DIFF
--- a/system/cms/themes/pyrocms/views/fragments/wysiwyg.php
+++ b/system/cms/themes/pyrocms/views/fragments/wysiwyg.php
@@ -34,7 +34,7 @@
 						['Link','Unlink'],
 						['Table','HorizontalRule','SpecialChar'],
 						['Bold','Italic','StrikeThrough'],
-						['JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock'],
+						['JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock','-','BidiLtr','BidiRtl'],
 						['Format', 'FontSize', 'Subscript','Superscript', 'NumberedList','BulletedList','Outdent','Indent','Blockquote'],
 						['ShowBlocks', 'RemoveFormat', 'Source']
 					],


### PR DESCRIPTION
Since PyroCMS is multi-language cms it should have this buttons to help us when using Right-To-Left languages like Arabic
Should we add this buttons to the simple WYSIWYG?
