### PR TITLE
Added inner_tag attribute to plugin

### DIFF
--- a/system/cms/modules/navigation/plugin.php
+++ b/system/cms/modules/navigation/plugin.php
@@ -16,7 +16,7 @@ class Plugin_Navigation extends Plugin
 	 *
 	 * Usage:
 	 * {{ navigation:links group="header" }}
-	 * Optional:  indent="", tag="li", list_tag="ul", top="text", separator="", group_segment="", class="", more_class=""
+	 * Optional:  indent="", tag="li", list_tag="ul", top="text", separator="", group_segment="", class="", more_class="", wrap=""
 	 * @param	array
 	 * @return	array
 	 */
@@ -55,7 +55,7 @@ class Plugin_Navigation extends Plugin
 		$first_class	= $this->attribute('first-class', 'first');
 		$last_class		= $this->attribute('last-class', 'last');
 		$output			= $return_arr ? array() : '';
-		$inner_tag		= $this->attribute('inner_tag');
+		$inner_tag		= $this->attribute('wrap');
 		$i		= 1;
 		$total	= sizeof($links);
 
@@ -98,9 +98,9 @@ class Plugin_Navigation extends Plugin
 			// attributes of anchor
 			$item['url']					= $link['url'];
 			$item['title']					= $link['title'];
-			if($inner_tag)
+			if($wrap)
 			{
-				$item['title']  = '<'.$inner_tag.'>'.$item['title'].'</'.$inner_tag.'>';
+				$item['title']  = '<'.$wrap.'>'.$item['title'].'</'.$wrap.'>';
 			}
 			
 			$item['attributes']['target']	= $link['target'] ? 'target="' . $link['target'] . '"' : NULL;


### PR DESCRIPTION
I added the ability to add an inner tag to the anchor link for the navigation plugin.
example {{ navigation:links group="header" inner_tag="span" }}
