### PR TITLE
Feature/extra triggers

### DIFF
--- a/system/cms/modules/blog/controllers/admin_categories.php
+++ b/system/cms/modules/blog/controllers/admin_categories.php
@@ -77,10 +77,18 @@ class Admin_Categories extends Admin_Controller {
 		// Validate the data
 		if ($this->form_validation->run())
 		{
-			$this->blog_categories_m->insert($_POST)
-				? $this->session->set_flashdata('success', sprintf( lang('cat_add_success'), $this->input->post('title')) )
-				: $this->session->set_flashdata('error', lang('cat_add_error'));
+			if ($id = $this->blog_categories_m->insert($_POST))
+			{
+				// Fire an event. A new blog category has been created.
+				Events::trigger('blog_category_created', $id);
 
+				$this->session->set_flashdata('success', sprintf( lang('cat_add_success'), $this->input->post('title')) );
+			}
+			else
+			{
+				$this->session->set_flashdata('error', lang('cat_add_error'));
+			}
+			
 			redirect('admin/blog/categories');
 		}
 		
@@ -117,6 +125,9 @@ class Admin_Categories extends Admin_Controller {
 				? $this->session->set_flashdata('success', sprintf( lang('cat_edit_success'), $this->input->post('title')) )
 				: $this->session->set_flashdata('error', lang('cat_edit_error'));
 			
+			// Fire an event. A blog category is being updated.
+			Events::trigger('blog_category_updated', $id);
+			
 			redirect('admin/blog/categories/index');
 		}
 		
@@ -150,11 +161,13 @@ class Admin_Categories extends Admin_Controller {
 		{
 			$deleted = 0;
 			$to_delete = 0;
+			$deleted_ids = array();
 			foreach ($id_array as $id)
 			{
 				if ($this->blog_categories_m->delete($id))
 				{
 					$deleted++;
+					$deleted_ids[] = $id;
 				}
 				else
 				{
@@ -167,6 +180,9 @@ class Admin_Categories extends Admin_Controller {
 			{
 				$this->session->set_flashdata('success', sprintf(lang('cat_mass_delete_success'), $deleted, $to_delete));
 			}
+			
+			// Fire an event. One or more categories have been deleted.
+			Events::trigger('blog_category_deleted', $deleted_ids);
 		}		
 		else
 		{

--- a/system/cms/modules/comments/controllers/admin.php
+++ b/system/cms/modules/comments/controllers/admin.php
@@ -156,6 +156,9 @@ class Admin extends Admin_Controller {
 				? $this->session->set_flashdata('success', lang('comments.edit_success'))
 				: $this->session->set_flashdata('error', lang('comments.edit_error'));
 
+			// Fire an event. A comment has been updated.
+			Events::trigger('comment_updated', $id);
+
 			redirect('admin/comments');
 		}
 
@@ -202,6 +205,9 @@ class Admin extends Admin_Controller {
 			(count($comments) == 1)
 				? $this->session->set_flashdata('success', sprintf(lang('comments.delete_single_success'), $comments[0]))				/* Only deleting one comment */
 				: $this->session->set_flashdata('success', sprintf(lang('comments.delete_multi_success'), implode(', #', $comments )));	/* Deleting multiple comments */
+		
+			// Fire an event. One or more comments were deleted.
+			Events::trigger('comment_deleted', $comments);
 		}
 
 		// For some reason, none of them were deleted
@@ -271,6 +277,10 @@ class Admin extends Admin_Controller {
 			{
 				// add an event so third-party devs can hook on
 				Events::trigger('comment_approved', $this->comments_m->get($id));
+			}
+			else
+			{
+				Events::trigger('comment_unapproved', $id);
 			}
 		}
 

--- a/system/cms/modules/files/controllers/admin.php
+++ b/system/cms/modules/files/controllers/admin.php
@@ -210,6 +210,9 @@ class Admin extends Admin_Controller {
 
 				if ($status === 'success')
 				{
+					// Fire an event. A file has been uploaded to a folder.
+					Events::trigger('file_uploaded', $data);
+
 					$this->session->set_flashdata($status, $message);
 					redirect('admin/files');
 				}
@@ -421,6 +424,11 @@ class Admin extends Admin_Controller {
 					redirect ('admin/files');
 				}
 			}
+			if ($status === 'success')
+			{
+				// Fire an event. A file has been updated.
+				Events::trigger('file_updated', $id);
+			}
 		}
 		elseif (validation_errors())
 		{
@@ -500,7 +508,13 @@ class Admin extends Admin_Controller {
 		{
 			$this->session->set_flashdata('error', lang('files.no_select_error'));
 		}
-
+		else
+		{
+			// or we fire an event because one or more files have been deleted.
+			Events::trigger('file_deleted', $deleted);			
+		}
+		
+		// Redirect
 		isset($folder) ? redirect('admin/files/#!path=' . $folder->virtual_path) : redirect('admin/files');
 	}
 

--- a/system/cms/modules/files/controllers/admin_folders.php
+++ b/system/cms/modules/files/controllers/admin_folders.php
@@ -219,7 +219,7 @@ class Admin_folders extends Admin_Controller {
 			}
 			else
 			{
-				if ($this->file_folders_m->insert(array(
+				if ($id = $this->file_folders_m->insert(array(
 					'name'			=> $name,
 					'slug'			=> $this->input->post('slug'),
 					'parent_id'		=> $this->input->post('parent_id'),
@@ -228,6 +228,9 @@ class Admin_folders extends Admin_Controller {
 				{
 					$message	= sprintf(lang('file_folders.create_success'), $name);
 					$status		= 'success';
+				
+					// Fire an event. A new folder has been created.
+					Events::trigger('file_folder_created', $id);
 				}
 				else
 				{
@@ -317,6 +320,9 @@ class Admin_folders extends Admin_Controller {
 			{
 				$message	= sprintf(lang('file_folders.create_success'), $name);
 				$status		= 'success';
+				
+				// Fire an event. A folder has been updated.
+				Events::trigger('file_folder_updated', $id);
 			}
 			else
 			{
@@ -384,6 +390,7 @@ class Admin_folders extends Admin_Controller {
 		{
 			$total		= sizeof($ids);
 			$deleted	= array();
+			$deleted_ids	= array();
 
 			// Try do deletion
 			foreach ($ids as $id)
@@ -393,8 +400,12 @@ class Admin_folders extends Admin_Controller {
 				{
 					// Make deletion retrieving an status and store an value to display in the messages
 					$deleted[($this->file_folders_m->delete($id) ? 'success': 'error')][] = $folder->name;
+					$deleted_ids[] = $id;
 				}
 			}
+
+			// Fire an event. One or more folders have been deleted.
+			Events::trigger('file_folder_deleted', $deleted_ids);
 
 			// Set status messages
 			foreach ($deleted as $status => &$values)

--- a/system/cms/modules/groups/controllers/admin.php
+++ b/system/cms/modules/groups/controllers/admin.php
@@ -70,10 +70,18 @@ class Admin extends Admin_Controller
 
 			if ($this->form_validation->run())
 			{
-				$this->group_m->insert($this->input->post())
-					? $this->session->set_flashdata('success', sprintf(lang('groups.add_success'), $this->input->post('name')))
-					: $this->session->set_flashdata('error', sprintf(lang('groups.add_error'), $this->input->post('name')));
-
+				if ($id = $this->group_m->insert($this->input->post()))
+				{
+					// Fire an event. A new group has been created.
+					Events::trigger('group_created', $id);
+					
+					$this->session->set_flashdata('success', sprintf(lang('groups.add_success'), $this->input->post('name')));
+				}
+				else
+				{
+					$this->session->set_flashdata('error', sprintf(lang('groups.add_error'), $this->input->post('name')));
+				}
+				
 				redirect('admin/groups');
 			}
 		}
@@ -121,10 +129,17 @@ class Admin extends Admin_Controller
 			
 			if ($this->form_validation->run())
 			{
-				$this->group_m->update($id, $this->input->post())
+				$success = $this->group_m->update($id, $this->input->post())
 					? $this->session->set_flashdata('success', sprintf(lang('groups.edit_success'), $this->input->post('name')))
 					: $this->session->set_flashdata('error', sprintf(lang('groups.edit_error'), $this->input->post('name')));
 
+				if ($success)
+				{
+					// Fire an event. A group has been updated.
+					Events::trigger('group_updated', $id);
+				}
+				
+				// Redirect
 				redirect('admin/groups');
 			}
 		}
@@ -144,10 +159,16 @@ class Admin extends Admin_Controller
 	 */
 	public function delete($id = 0)
 	{
-		$this->group_m->delete($id)
+		$success = $this->group_m->delete($id)
 			? $this->session->set_flashdata('success', lang('groups.delete_success'))
 			: $this->session->set_flashdata('error', lang('groups.delete_error'));
 
+		if ($success)
+		{
+			// Fire an event. A group has been deleted.
+			Events::trigger('group_deleted', $id);
+		}
+				
 		redirect('admin/groups');
 	}
 }

--- a/system/cms/modules/keywords/controllers/admin.php
+++ b/system/cms/modules/keywords/controllers/admin.php
@@ -65,10 +65,18 @@ class Admin extends Admin_Controller
 			
 			if ($this->form_validation->run())
 			{
-				$this->keyword_m->insert(array('name' => $name))
-					? $this->session->set_flashdata('success', sprintf(lang('keywords:add_success'), $name))
-					: $this->session->set_flashdata('error', sprintf(lang('keywords:add_error'), $name));
-
+				if ($id = $this->keyword_m->insert(array('name' => $name)))
+				{
+					// Fire an event. A new keyword has been added.
+					Events::trigger('keyword_created', $id);
+					
+					$this->session->set_flashdata('success', sprintf(lang('keywords:add_success'), $name));
+				}
+				else
+				{
+					$this->session->set_flashdata('error', sprintf(lang('keywords:add_error'), $name));
+				}
+				
 				redirect('admin/keywords');
 			}
 		}
@@ -108,10 +116,16 @@ class Admin extends Admin_Controller
 			
 			if ($this->form_validation->run())
 			{
-				$this->keyword_m->update($id, array('name' => $name))
+				$success = $this->keyword_m->update($id, array('name' => $name))
 					? $this->session->set_flashdata('success', sprintf(lang('keywords:edit_success'), $name))
 					: $this->session->set_flashdata('error', sprintf(lang('keywords:edit_error'), $name));
 
+				if ($success)
+				{
+					// Fire an event. A keyword has been updated.
+					Events::trigger('keyword_updated', $id);
+				}
+				
 				redirect('admin/keywords');
 			}
 		}
@@ -131,9 +145,15 @@ class Admin extends Admin_Controller
 	 */
 	public function delete($id = 0)
 	{
-		$this->keyword_m->delete($id)
+		$success = $this->keyword_m->delete($id)
 			? $this->session->set_flashdata('success', lang('keywords:delete_success'))
 			: $this->session->set_flashdata('error', lang('keywords:delete_error'));
+		
+		if ($success)
+		{
+			// Fire an event. A keyword has been deleted.
+			Events::trigger('keyword_deleted', $id);
+		}
 
 		redirect('admin/keywords');
 	}

--- a/system/cms/modules/modules/controllers/admin.php
+++ b/system/cms/modules/modules/controllers/admin.php
@@ -81,6 +81,9 @@ class Admin extends Admin_Controller
 					{
 						if ($this->module_m->install($slug, FALSE, TRUE))
 						{
+							// Fire an event. A module has been enabled when uploaded. 
+							Events::trigger('module_enabled', $slug);
+		
 							$this->session->set_flashdata('success', sprintf(lang('modules.install_success'), $slug));
 						}
 						else
@@ -127,6 +130,9 @@ class Admin extends Admin_Controller
 		if ($this->module_m->uninstall($slug))
 		{
 			$this->session->set_flashdata('success', sprintf(lang('modules.uninstall_success'), $slug));
+			
+			// Fire an event. A module has been disabled when uninstalled. 
+			Events::trigger('module_disabled', $slug);
 
 			redirect('admin/modules');
 		}
@@ -168,6 +174,9 @@ class Admin extends Admin_Controller
 				}
 			}
 
+			// Fire an event. A module has been disabled when deleted. 
+			Events::trigger('module_disabled', $slug);
+			
 			redirect('admin/modules');
 		}
 
@@ -188,6 +197,9 @@ class Admin extends Admin_Controller
 	{
 		if ($this->module_m->install($slug))
 		{
+			// Fire an event. A module has been enabled when installed. 
+			Events::trigger('module_enabled', $slug);
+							
 			// Clear the module cache
 			$this->pyrocache->delete_all('module_m');
 			$this->session->set_flashdata('success', sprintf(lang('modules.install_success'), $slug));
@@ -213,6 +225,9 @@ class Admin extends Admin_Controller
 	{
 		if ($this->module_m->enable($slug))
 		{
+			// Fire an event. A module has been enabled. 
+			Events::trigger('module_enabled', $slug);
+			
 			// Clear the module cache
 			$this->pyrocache->delete_all('module_m');
 			$this->session->set_flashdata('success', sprintf(lang('modules.enable_success'), $slug));
@@ -238,6 +253,9 @@ class Admin extends Admin_Controller
 	{
 		if ($this->module_m->disable($slug))
 		{
+			// Fire an event. A module has been disabled. 
+			Events::trigger('module_disabled', $slug);
+			
 			// Clear the module cache
 			$this->pyrocache->delete_all('module_m');
 			$this->session->set_flashdata('success', sprintf(lang('modules.disable_success'), $slug));
@@ -264,6 +282,9 @@ class Admin extends Admin_Controller
 		// If upgrade succeeded
 		if ($this->module_m->upgrade($slug))
 		{
+			// Fire an event. A module has been upgraded. 
+			Events::trigger('module_upgraded', $slug);
+			
 			$this->session->set_flashdata('success', sprintf(lang('modules.upgrade_success'), $slug));
 		}
 		// If upgrade failed

--- a/system/cms/modules/navigation/controllers/admin_groups.php
+++ b/system/cms/modules/navigation/controllers/admin_groups.php
@@ -72,9 +72,11 @@ class Admin_groups extends Admin_Controller {
 		if ($this->form_validation->run())
 		{
 			// Insert the new group
-			if ($this->navigation_m->insert_group($_POST) > 0)
+			if ($id = $this->navigation_m->insert_group($_POST) > 0)
 			{
 				$this->session->set_flashdata('success', $this->lang->line('nav_group_add_success'));
+				// Fire an event. A new navigation group has been created.
+				Events::trigger('navigation_group_created', $id);
 			}
 			else
 			{
@@ -106,11 +108,16 @@ class Admin_groups extends Admin_Controller {
 	 */
 	public function delete($id = 0)
 	{
+		$deleted_ids = FALSE;
+		
 		// Delete one
-		if($id)
+		if ($id)
 		{
-			$this->navigation_m->delete_group($id);
-			$this->navigation_m->delete_link(array('navigation_group_id'=>$id));
+			if ($this->navigation_m->delete_group($id))
+			{
+				$deleted_ids[] = $id;
+				$this->navigation_m->delete_link(array('navigation_group_id'=>$id));
+			};
 		}
 
 		// Delete multiple
@@ -118,9 +125,18 @@ class Admin_groups extends Admin_Controller {
 		{
 			foreach (array_keys($this->input->post('delete')) as $id)
 			{
-				$this->navigation_m->delete_group($id);
-				$this->navigation_m->delete_link(array('navigation_group_id'=>$id));
+				if ($this->navigation_m->delete_group($id))
+				{
+					$deleted_ids[] = $id;
+					$this->navigation_m->delete_link(array('navigation_group_id'=>$id));
+				}
 			}
+		}
+		
+		// Fire an event. One or more navigation groups have been deleted.
+		if ( ! empty($deleted_ids))
+		{
+			Events::trigger('navigation_group_deleted', $deleted_ids);
 		}
 
 		// Set the message and redirect

--- a/system/cms/modules/permissions/controllers/admin.php
+++ b/system/cms/modules/permissions/controllers/admin.php
@@ -44,9 +44,15 @@ class Admin extends Admin_Controller
 
 		if ($_POST)
 		{
+			$modules = $this->input->post('modules');
+			$roles = $this->input->post('module_roles');
+
 			// save the permissions
-			$this->permission_m->save($group_id, $this->input->post('modules'), $this->input->post('module_roles'));
-			
+			$this->permission_m->save($group_id, $modules, $roles);
+
+			// Fire an event. Permissions have been saved.
+			Events::trigger('permissions_saved', array($group_id, $modules, $roles));
+
 			$this->session->set_flashdata('success', lang('permissions.message_group_saved'));
 
 			redirect('admin/permissions/group/'.$group_id);

--- a/system/cms/modules/settings/controllers/admin.php
+++ b/system/cms/modules/settings/controllers/admin.php
@@ -167,6 +167,9 @@ class Admin extends Admin_Controller {
 					$this->settings->set_item($slug, $input_value);
 				}
 			}
+			
+			// Fire an event. Yay! We know when settings are updated. 
+			Events::trigger('settings_updated', $settings_stored);
 
 			// Success...
 			$this->session->set_flashdata('success', $this->lang->line('settings_save_success'));

--- a/system/cms/modules/templates/controllers/admin.php
+++ b/system/cms/modules/templates/controllers/admin.php
@@ -130,8 +130,11 @@ class Admin extends Admin_Controller {
                 $data[$key] = $this->input->post($key);
             }
             unset($data['btnAction']);
-            if($this->email_templates_m->insert($data))
+            if ($id = $this->email_templates_m->insert($data))
             {
+                // Fire an event. A new email template has been created.
+                Events::trigger('email_template_created', $id);
+
                 $this->session->set_flashdata('success', sprintf(lang('templates.tmpl_create_success'), $data['name']));
             }
             else
@@ -193,6 +196,9 @@ class Admin extends Admin_Controller {
 
             if($this->email_templates_m->update($id, $data))
             {
+                // Fire an event. An email template has been updated.
+                Events::trigger('email_template_updated', $id);
+
                 $this->session->set_flashdata('success', sprintf(lang('templates.tmpl_edit_success'), $email_template->name));
             }
             else
@@ -247,6 +253,9 @@ class Admin extends Admin_Controller {
 			{
 				if (sizeof($ids) > 1)
 				{
+					// Fire an event. An email template has been deleted.
+					Events::trigger('email_template_deleted', $id);
+
 					$this->session->set_flashdata('success', sprintf(lang('templates.mass_delete_success'), $deleted, $to_delete));
 				}
 				else
@@ -314,13 +323,16 @@ class Admin extends Admin_Controller {
 
         $this->form_validation->set_rules($this->_clone_rules);
 
-        if($this->form_validation->run())
+        if ($this->form_validation->run())
         {
             //insert stuff to db
             $copy->lang = $this->input->post('lang');
 
-            if($new_id = $this->email_templates_m->insert($copy))
+            if ($new_id = $this->email_templates_m->insert($copy))
             {
+                // Fire the "created" event here also.
+                Events::trigger('email_template_created');
+
                 $this->session->set_flashdata('success', sprintf(lang('templates.tmpl_clone_success'), $copy->name));
                 redirect('admin/templates/edit/' . $new_id);
             }

--- a/system/cms/modules/themes/controllers/admin.php
+++ b/system/cms/modules/themes/controllers/admin.php
@@ -139,6 +139,9 @@ class Admin extends Admin_Controller
 					}
 				}
 	
+				// Fire an event. Theme options have been updated. 
+				Events::trigger('theme_options_updated', $options_array);
+					
 				// Success...
 				$data = array();
 				$data['messages']['success'] = lang('themes.save_success');
@@ -185,6 +188,9 @@ class Admin extends Admin_Controller
 		// Set the theme
 		if ($this->theme_m->set_default($this->input->post()))
 		{
+			// Fire an event. A default theme has been set. 
+			Events::trigger('theme_set_default', $theme);
+				
 			$this->session->set_flashdata('success', sprintf(lang('themes.set_default_success'), $theme));
 		}
 
@@ -282,6 +288,8 @@ class Admin extends Admin_Controller
 		{
 			$deleted = 0;
 			$to_delete = 0;
+			$deleted_names = array();
+			
 			foreach ($name_array as $theme_name)
 			{
 				$theme_name = urldecode($theme_name);
@@ -303,6 +311,7 @@ class Admin extends Admin_Controller
 						if (@rmdir($theme_dir))
 						{
 							$deleted++;
+							$deleted_names[] = $theme_name;
 						}
 					}
 
@@ -315,6 +324,9 @@ class Admin extends Admin_Controller
 
 			if ($deleted == $to_delete)
 			{
+				// Fire an event. One or more themes have been deleted. 
+				Events::trigger('theme_deleted', $deleted_names);
+				
 				$this->session->set_flashdata('success', sprintf(lang('themes.mass_delete_success'), $deleted, $to_delete) );
 			}
 		}

--- a/system/cms/modules/users/controllers/admin.php
+++ b/system/cms/modules/users/controllers/admin.php
@@ -190,6 +190,9 @@ class Admin extends Admin_Controller {
 			// Try to register the user
 			if ($user_id = $this->ion_auth->register($username, $password, $email, $user_data, $group->name))
 			{
+				// Fire an event. A new user has been created. 
+				Events::trigger('user_created', $user_id);
+		
 				// Set the flashdata message and redirect
 				$this->session->set_flashdata('success', $this->ion_auth->messages());
 				redirect('admin/users');
@@ -275,6 +278,9 @@ class Admin extends Admin_Controller {
 
 			if ($this->ion_auth->update_user($id, $update_data))
 			{
+				// Fire an event. A user has been updated. 
+				Events::trigger('user_updated', $id);
+				
 				$this->session->set_flashdata('success', $this->ion_auth->messages());
 			}
 			else
@@ -375,6 +381,7 @@ class Admin extends Admin_Controller {
 		{
 			$deleted = 0;
 			$to_delete = 0;
+			$deleted_ids = array();
 			foreach ($ids as $id)
 			{
 				// Make sure the admin is not trying to delete themself
@@ -386,6 +393,7 @@ class Admin extends Admin_Controller {
 
 				if ($this->ion_auth->delete_user($id))
 				{
+					$deleted_ids[] = $id;
 					$deleted++;
 				}
 				$to_delete++;
@@ -393,6 +401,9 @@ class Admin extends Admin_Controller {
 
 			if ($to_delete > 0)
 			{
+				// Fire an event. One or more users have been deleted. 
+				Events::trigger('user_deleted', $deleted_ids);
+				
 				$this->session->set_flashdata('success', sprintf(lang('user_mass_delete_success'), $deleted, $to_delete));
 			}
 		}

--- a/system/cms/modules/widgets/controllers/admin.php
+++ b/system/cms/modules/widgets/controllers/admin.php
@@ -182,6 +182,20 @@ class Admin extends Admin_Controller {
 				$status = 'error';
 				break;
 			}
+			else
+			{
+				// Fire an Event. A widget has been enabled or disabled. 
+				switch ($action)
+				{
+					case 'enable':		
+						Events::trigger('widget_enabled', $ids);
+						break;
+					
+					case 'disable':		
+						Events::trigger('widget_disabled', $ids);
+						break;
+				}
+			}
 		}
 
 		$this->session->set_flashdata( array($status=> lang('widgets.'.$action.'_'.$status.$multiple)));

--- a/system/cms/modules/widgets/controllers/admin_areas.php
+++ b/system/cms/modules/widgets/controllers/admin_areas.php
@@ -96,6 +96,9 @@ class Admin_areas extends Admin_Controller {
 
 			if ($id = $this->widgets->add_area($input))
 			{
+				// Fire an event. A widget area has been created. 
+				Events::trigger('widget_area_created');
+								
 				$area		= $this->widgets->get_area($id);
 				$status		= 'success';
 				$message	= lang('success_label');
@@ -183,6 +186,9 @@ class Admin_areas extends Admin_Controller {
 
 			if ($this->widgets->edit_area($input))
 			{
+				// Fire an event. A widget area has been updated. 
+				Events::trigger('widget_area_updated', $id);
+				
 				$area = $this->widgets->get_area($id);
 				$status		= 'success';
 				$message	= lang('success_label');
@@ -251,6 +257,9 @@ class Admin_areas extends Admin_Controller {
 	{
 		if ($this->widgets->delete_area($id))
 		{
+			// Fire an event. A widget area has been deleted. 
+			Events::trigger('widget_area_deleted', $id);
+				
 			$status = 'success';
 			$message = lang('success_label');
 		}

--- a/system/cms/modules/widgets/controllers/admin_instances.php
+++ b/system/cms/modules/widgets/controllers/admin_instances.php
@@ -100,6 +100,9 @@ class Admin_instances extends Admin_Controller {
 
 			if ($result['status'] === 'success')
 			{
+				// Fire an event. A widget instance has been created. 
+				Events::trigger('widget_instance_created', $id);
+				
 				$status		= 'success';
 				$message	= lang('success_label');
 
@@ -174,6 +177,9 @@ class Admin_instances extends Admin_Controller {
 
 			if ($result['status'] === 'success')
 			{
+				// Fire an event. A widget instance has been updated. 
+				Events::trigger('widget_instance_updated', $id);
+				
 				$status		= 'success';
 				$message	= lang('success_label');
 
@@ -229,6 +235,9 @@ class Admin_instances extends Admin_Controller {
 	{
 		if ($this->widgets->delete_instance($id))
 		{
+			// Fire an event. A widget instance has been deleted. 
+			Events::trigger('widget_instance_deleted', $id);
+				
 			$status = 'success';
 			$message = lang('success_label');
 		}


### PR DESCRIPTION
@philsturgeon, @adamfairholm

As we agreed, I am sending this to 2.1/develop

Also, I updated the "create" triggers to pass the id of the inserted data where applicable.

Reminder: For this to work, the corresponding models need to be fixed to return the id.

I suggest that we set a standard for naming triggers. It might be more intuitive for developers to find triggers beginning with the name of the module.

We can revisit this later when we have time.

Copy / pasting some notes for future reference...

This time I tried following these rules when placing triggers:
1. Use simple and meaningful names
2. Place them where success has been checked
3. Repeat a trigger in places where it is relevant. (like modules)
4. For create, update and delete operations, pass the inserted ids.

The list of new triggers:

blog_article_deleted
blog_category_created
blog_category_updated
blog_category_deleted

comment_updated
comment_deleted
comment_unapproved

file_uploaded
file_updated
file_deleted
file_folder_created
file_folder_updated
file_folder_deleted

group_created
group_updated
group_deleted

keyword_created
keyword_updated
keyword_deleted

module_enabled
module_disabled

navigation_group_created
navigation_group_deleted

permissions_saved

settings_updated

email_template_created
email_template_updated
email_template_deleted

theme_options_updated
theme_set_default
theme_deleted

user_created
user_updated
user_deleted

widget_enabled
widget_disabled
widget_area_created
widget_area_updated
widget_area_deleted
widget_instance_created
widget_instance_updated
widget_instance_deleted
