### PR TITLE
Update system/cms/modules/pages/plugin.php

### DIFF
--- a/system/cms/modules/pages/plugin.php
+++ b/system/cms/modules/pages/plugin.php
@@ -56,7 +56,7 @@ class Plugin_Pages extends Plugin
 		// we'll unset the chunks array as Lex is grouchy about mixed data at the moment
 		unset($page['chunks']);
 
-		return $this->content() ? $page : $page['body'];
+		return $this->content() ? array($page) : $page['body'];
 	}
 
 	// --------------------------------------------------------------------------


### PR DESCRIPTION
Fixed the display method to properly return the $pages data array as an index within another array. This is important to make the following example code work...

```
{{ pages:children id="1" limit="2" }}
    <h2>{{ title }}</h2>
    {{ body }}
{{ /pages:children }}
```

Otherwise you're looping through the pages data and not results.
