### PR TITLE
Javascript files not working in 2.1/develop

### DIFF
--- a/system/cms/plugins/theme.php
+++ b/system/cms/plugins/theme.php
@@ -191,7 +191,7 @@ class Plugin_Theme extends Plugin
 	public function js($return = '')
 	{
 		$file = $this->attribute('file');
-		return '<script src="'.$this->js_path($file).'" type="text/css"></script>';
+		return '<script src="'.$this->js_path($file).'" type="text/javascript"></script>';
 	}
 
 	/**


### PR DESCRIPTION
When you use {{theme:js file=" "}}

it got the wrong type !

system/cms/plugins/theme.php
line : 194
the type = text/css
and must be text/javascript
