### PR TITLE
Patch 1

### DIFF
--- a/system/cms/libraries/Asset.php
+++ b/system/cms/libraries/Asset.php
@@ -13,6 +13,7 @@
  * @author   Phil Sturgeon
  * @package    PyroCMS\Core\Libraries\Asset
  */
+class Asset_Exception extends Exception {}
 
 include('Asset/jsmin.php');
 include('Asset/csscompressor.php');
@@ -1306,7 +1307,5 @@ class Asset {
 		return trim($attr_str);
 	}
 }
-
-class Asset_Exception extends Exception {}
 
 /* End of file asset_php */


### PR DESCRIPTION
This pull request will fix issue #1145 where Asset/jsmin requires the class Asset_Exception -- which is loaded only at the end of the file Asset.php. 

This pull places

class Asset_Exception extends Exception {}

to before the includes of the file.
