### PR TITLE
Patch 7

### DIFF
--- a/system/cms/modules/pages/plugin.php
+++ b/system/cms/modules/pages/plugin.php
@@ -101,11 +101,10 @@ class Plugin_Pages extends Plugin
 		$order_dir		= $this->attribute('order-dir', 'ASC');
 		
 		return $this->db
-			->select('pages.*, page_chunks.body')
+			->select('pages.*')
 			->where('pages.parent_id', $this->attribute('id'))
 			->where('status', 'live')
 			->order_by($order_by, $order_dir)
-			->join('page_chunks', 'pages.id = page_chunks.page_id', 'LEFT')
 			->limit($limit)
 			->get('pages')
 			->result_array();


### PR DESCRIPTION
This join causes there to be multiple indexes of the same page within a result if you have more than one chunk defined in a page. I could have run an additional query here to get page chunks separately for each returned page however this is easily achieved using the {{page:chunk}} method so I felt ir redundant. You guys have any thoughts?
