### PR TITLE
Default to base theme fixes

### DIFF
--- a/system/cms/themes/base/views/partials/slider.html
+++ b/system/cms/themes/base/views/partials/slider.html
@@ -1,3 +1,4 @@
+{{ noparse }}
 <!--
 - If you have enabled the slider via the theme 
 - options(Admin > Design > Themes > Base > Options) 
@@ -8,6 +9,7 @@ if you've uploaded them into the themes image
 - directory(addons/<site_ref>/themes/base/img/)
 - you can use {{ theme:image file="filename.jpg" }}
 -->
+{{ /noparse }}
 <div class="flexslider">
 	<ul class="slides">
 		<li>{{ theme:image file="responsive.jpg" }}</li>


### PR DESCRIPTION
{{ theme:image file="filename.jpg" }} produced errors in the theme, regardless of it being in a comment.
