### PR TITLE
Disabling Dashboard RSS feed on Community Edition

### DIFF
--- a/system/cms/themes/pyrocms/views/admin/dashboard.php
+++ b/system/cms/themes/pyrocms/views/admin/dashboard.php
@@ -151,8 +151,8 @@ $(function($) {
 
 	<!-- Display RSS Block: Only show if Dashboard RSS Items is greater than zero -->
 	<?php if ( count($rss_items) > 0) : ?>
-	<div id="feed" class="one_full">
-		
+	
+	<div id="feed" class="one_full">	
 		<section class="draggable title">
 			<h4><?php echo lang('cp_news_feed_title'); ?></h4>
 			<a class="tooltip-s toggle" title="Toggle this element"></a>


### PR DESCRIPTION
Hopefully I don't break the Internets. This is my first Pull Request ever. And first time truly working with Git. Excuse my ignorance. Here’s my contribution…

The Community Edition doesn’t allow for disabling the Dashboard RSS block. Commit #a77e2aab provides this feature if the user has set the feed count in Settings to zero.

Note: Commit #4d97f666 is a duplicate of the first with the exception of an extra carriage return.
