### PR TITLE
added max-width declarations to tame analytics chart

### DIFF
--- a/system/cms/themes/pyrocms/css/workless.css
+++ b/system/cms/themes/pyrocms/css/workless.css
@@ -2163,6 +2163,21 @@ Ensure your main styling comes before this!
 
 }
 
+/*Target iPad specifically*/
+@media only screen and (min-device-width: 768px) and (max-device-width: 1024px) {
+
+	#analyticsWrapper {
+		max-width: 93.6%;
+	}
+
+	#analytics {
+	max-width: 100%;
+	}
+}
+
+
+
+
 @media only screen and (min-width: 1025px) {
 
 	.wrapper {


### PR DESCRIPTION
The Google analytics chart in the admin panel dashboard persistently stuck out from the box on the
dashboard, so I added max-width declarations to tame it in the workless.css file of the system/cms/themes/pyrocms theme. Only tested on
mac: safari/chrome/ff and iOS: safari
