### PR TITLE
Fix "Top" link in the footer of the default theme

### DIFF
--- a/system/cms/themes/default/views/partials/footer.html
+++ b/system/cms/themes/default/views/partials/footer.html
@@ -4,7 +4,7 @@
 	<div id="poweredby"><a href="http://pyrocms.com/">{{ theme:image file="logo.png" alt="Powered by PyroCMS" }} {{ helper:lang line="powered_by_pyrocms" }}</a></div>
 	<ul id="foot-nav">
 		{{ navigation:links group="footer" }}
-		<li><a class="last" href="#top" title="{{ helper:lang line="back_to_top" }}">{{ helper:lang line="top_page" }} &uarr;</a></li>
+		<li><a class="last" href="{{ url:current }}#top" title="{{ helper:lang line="back_to_top" }}">{{ helper:lang line="top_page" }} &uarr;</a></li>
 		<li>&copy;{{ helper:date format="Y" }} {{ settings:site_name }}. {{ helper:lang line="all_right_reserved" }}</li>
 	</ul>
 </footer>


### PR DESCRIPTION
Due to the use of the `<base>` tag, anchors (e.g. "#top") were relative
to the page defined in the <base> tag (the home page), rather than the
current page.

This meant that clicking on the "Top" link on e.g. the contact page would
load the home page, then scroll to the top of that. The result was a
confusing first impression for anyone playing with a default install of
the site.

The fix was to add {{ url:current }} before the #top in the anchor.
