### PR TITLE
Trivial fix: Fix broken string interpolation in exception message

### DIFF
--- a/system/cms/libraries/MY_Form_validation.php
+++ b/system/cms/libraries/MY_Form_validation.php
@@ -175,7 +175,7 @@ class MY_Form_validation extends CI_Form_validation
 			{
 				if ( ! method_exists(CI::$APP->controller, $rule))
 				{
-					throw new Exception('Undefined callback "$rule" in '.CI::$APP->controller);
+					throw new Exception('Undefined callback "'.$rule.'" in '.CI::$APP->controller);
 				}
 
 				// Run the function and grab the result


### PR DESCRIPTION
This is a trivial fix.

The exception thrown when a validation callback was not found included the
name of the nonexistent callback. However, the variable was used inside
single quotes, and therefore did not interpolate correctly.
