### PR TITLE
The GMT timezone is deprecated

### DIFF
--- a/index.php
+++ b/index.php
@@ -85,7 +85,7 @@ define('ENVIRONMENT', (isset($_SERVER['PYRO_ENV']) ? $_SERVER['PYRO_ENV'] : PYRO
 	// PHP 5.3 will BITCH without this
 	if(ini_get('date.timezone') == '')
 	{
-		date_default_timezone_set('GMT');
+		date_default_timezone_set('UTC');
 	}
 
 


### PR DESCRIPTION
The GMT timezone is [deprecated](http://www.php.net/manual/en/timezones.others.php).

Maybe Europe/London or UTC is better, I've gone with the with latter to maintain International Relationships. :)
