### PR TITLE
Feature/ckeditor image fix

### DIFF
--- a/system/cms/themes/pyrocms/js/ckeditor/plugins/pyroimages/plugin.js
+++ b/system/cms/themes/pyrocms/js/ckeditor/plugins/pyroimages/plugin.js
@@ -27,6 +27,18 @@ CKEDITOR.plugins.add('pyroimages',
 				command.setState(CKEDITOR.TRISTATE_DISABLED);
 			}
 		});
+
+		// When the "Image Properties" dialog windows is closed with the OK button, ckeditor inserts the updated element into the editor
+		// without calling the dataProcessor on it.
+		// This results in the image appearing as broken, as the {{ url:site }} isn't filtered out.
+		// We overcome this by hooking into the dialogHide event for the "Image Properties" dialog, and triggering an event
+		// which causes the newly-updated element (and everything else) to be processed by the dataProcessor.
+		editor.on('dialogHide', function(e) {
+			if (e.data.getName() != 'image')
+				return;
+
+			editor.fire('afterSetData');
+		});
 	},
 
 	// Create a filter which re-writes {{ url:site }} and {{ url:base }} to the JS constants SITE_URL and BASE_URL when rendering a wysiwyg preview


### PR DESCRIPTION
Since ff442ef24e, a newly-inserted image contained {{ url:site }}, and the ckeditor dataProcesser was taught to replace these with the constant SITE_URL. However, the "Image Properties" dialog would update the raw element, without bothering to call the dataProcessor on it, resulting in {{ url:site }} not being replaced, and a broken image.

This patch teaches ckeditor to call the dataProcessor whenever the "Image Properties" dialog is closed.

I've based this commit on 2.0/develop, as it can be seen as a regression fix. However, I'm happy to rebase it if you want.
