### PR TITLE
2.1/develop - Fix false positives for "invalid file type"

### DIFF
--- a/system/cms/modules/files/js/functions.js
+++ b/system/cms/modules/files/js/functions.js
@@ -394,7 +394,7 @@ jQuery(function($){
 				var regexp = new RegExp(pyro.files.valid_extensions);
 				// Using the filename extension for our test,
 				// as legacy browsers don't report the mime type
-				if (!regexp.test(files[index].name)) {
+				if (!regexp.test(files[index].name.toLowerCase())) {
 					$progress_div.html(pyro.lang.file_type_not_allowed);
 					return false;
 				}


### PR DESCRIPTION
When the file extension is UPPERCASE it flags it as a "Invalid file type"
