### PR TITLE
Allow for more than one Google Maps per page.

### DIFF
--- a/system/cms/widgets/google_maps/views/display.php
+++ b/system/cms/widgets/google_maps/views/display.php
@@ -1,15 +1,23 @@
+<?php
+if (isset($options["widget"])) {   // for use with widget instances
+  $instanceId = $options["widget"]["instance_id"];
+}
+else {
+  $instanceId = rand(2000,3000);   // for use with widget area
+}
+?>
 <script type='text/javascript' src='http://maps.google.com/maps/api/js?sensor=false'></script>
 <script type='text/javascript'>
     (function($)
     {
         $(document).ready(function()
         {
-            var canvas = $('div#gmap_canvas');
-            canvas.css('width',<?php echo '"' . $options['width'] . '"'; ?>);
-            canvas.css('height',<?php echo '"' . $options['height'] . '"'; ?>);
+            var canvas<?php echo $instanceId; ?> = $('div#gmap_canvas<?php echo $instanceId; ?>');
+            canvas<?php echo $instanceId; ?>.css('width',<?php echo '"' . $options['width'] . '"'; ?>);
+            canvas<?php echo $instanceId; ?>.css('height',<?php echo '"' . $options['height'] . '"'; ?>);
 
-            var geocoder = new google.maps.Geocoder();
-            geocoder.geocode(
+            var geocoder<?php echo $instanceId; ?> = new google.maps.Geocoder();
+            geocoder<?php echo $instanceId; ?>.geocode(
             {
                address : <?php echo '"' . $options['address'] . '"'; ?>
             }, function(results, status)
@@ -17,7 +25,7 @@
                 if ( status == google.maps.GeocoderStatus.OK)
                 {
                     var latlng = results[0].geometry.location;
-                    var map = new google.maps.Map(canvas.get(0),
+                    var map = new google.maps.Map(canvas<?php echo $instanceId; ?>.get(0),
                     {
                        zoom : <?php echo $options['zoom']; ?>,
                        center : latlng,
@@ -59,4 +67,4 @@
     })(jQuery);
 </script>
 
-<div id='gmap_canvas'></div>
+<div id='gmap_canvas<?php echo $instanceId; ?>'></div>


### PR DESCRIPTION
The current Google Maps widget allows for just one map per page. Fine for most sites, but a website I'm currently building requires two (one per office) on their contact page. Hence, this amendment.
