### PR TITLE
fixes: #1284 missing basic_layout.css in pyroimages dialog

### DIFF
--- a/system/cms/modules/wysiwyg/controllers/image.php
+++ b/system/cms/modules/wysiwyg/controllers/image.php
@@ -52,6 +52,7 @@ class Image extends WYSIWYG_Controller {
 
 		$this->template
 			->title('Images')
+			->append_css('admin/basic_layout.css')
 			->build('image/index', $data);
 	}
 


### PR DESCRIPTION
The pyroimages dialog in the wysiwyg editor is missing it's basic layouts.
I'm not really sure if this is the way to go and I'd rather do a 'prepend_css()' than an 'append_css()' (which doesn't exist and as far as i can tell the Asset Library doesn't support any asset ordering)... but hey: the dialog looks pretty again.
