### PR TITLE
2.1 - Fixed group_has_role to check array instead of a nonexistent object

### DIFF
--- a/system/cms/modules/users/helpers/user_helper.php
+++ b/system/cms/modules/users/helpers/user_helper.php
@@ -30,7 +30,7 @@ function group_has_role($module, $role)
 
 	$permissions = ci()->permission_m->get_group(ci()->current_user->group_id);
 
-	if (empty($permissions[$module]) or empty($permissions[$module]->$role))
+	if (empty($permissions[$module]) or empty($permissions[$module][$role]))
 	{
 		return FALSE;
 	}


### PR DESCRIPTION
This seems pretty important, any one that is not in the  admin group and has access from other group permissions will be denied
