### PR TITLE
Updated pyro.generate_slug() to allow custom space converter

### DIFF
--- a/system/cms/themes/pyrocms/js/scripts.js
+++ b/system/cms/themes/pyrocms/js/scripts.js
@@ -345,7 +345,7 @@ jQuery(function($) {
 	}
 
 	// Create a clean slug from whatever garbage is in the title field
-	pyro.generate_slug = function(input_form, output_form)
+	pyro.generate_slug = function(input_form, output_form, space_character)
 	{
 		var slug, value;
 
@@ -353,11 +353,15 @@ jQuery(function($) {
 			value = $(input_form).val();
 
 			if ( ! value.length ) return;
-
+			
+			space_character = space_character || '-';
 			var rx = /[a-z]|[A-Z]|[0-9]|[áàâąбćčцдđďéèêëęěфгѓíîïийкłлмñńňóôóпúùûůřšśťтвýыžżźзäæœчöøüшщßåяюжαβγδεέζηήθιίϊκλμνξοόπρστυύϋφχψωώ]/,
 				value = value.toLowerCase(),
 				chars = pyro.foreign_characters,
+				space_regex = new RegExp('[' + space_character + ']+','g'),
+				space_regex_trim = new RegExp('^[' + space_character + ']+|[' + space_character + ']+$','g'),
 				search, replace;
+			
 
 			// If already a slug then no need to process any further
 		    if (!rx.test(value)) {
@@ -375,8 +379,9 @@ jQuery(function($) {
 		        };
 
 		        slug = value.replace(/[^-a-z0-9~\s\.:;+=_]/g, '')
-		        			.replace(/[\s\.:;=+]+/g, '-')
-		        			.replace(/[-]+/g, '-');
+		        			.replace(/[\s\.:;=+]+/g, space_character)
+		        			.replace(space_regex, space_character)
+		        			.replace(space_regex_trim, '');
 		    }
 
 			$(output_form).val(slug);


### PR DESCRIPTION
1. Updated pyro.generate_slug() to allow a third parameter for changing the default dash to something else like underscore: `pyro.generate_slug(input, output, '_')` will convert `This text is awe-some` to `this_text_is_awe-some`; preserves dashes in this case since a word might be something like "tongue-in-cheek"
2. Changed the function to disallow the space character at the beginning or end of the slug. Example: `This text is awesome...` used to produce `this-text-is-awesome-`. Now it produces `this-text-is-awesome`.

These changes were implemented to allow people using PyroSnippets to generate a slug without dashes since calling `{{ snippet:some-var-name }}` would error out. This function can also now be used to replace `slugify()` which is a JS function used in Streams for slug fields. The `slugify()` function does not support as many characters as the `pyro.generate_slug()` function.

If this goes through, I can change those old functions to the new one, as well as create an additional function that will simply take and convert text without automatically duplicating it to a new field.
