### PR TITLE
Resolved notice associated to assigning a value by reference to an overl...

### DIFF
--- a/system/cms/libraries/Template.php
+++ b/system/cms/libraries/Template.php
@@ -37,6 +37,8 @@ class Template
 	private $_parser_body_enabled = TRUE;
 	private $_minify_enabled = FALSE;
 
+	private $_navigation_group = NULL;
+
 	private $_theme_locations = array();
 
 	private $_is_mobile = FALSE;
@@ -621,6 +623,19 @@ class Template
 		}
 
 		return FALSE;
+	}
+
+	/**
+	 * Setter/Getter for _navigation_group
+	 * 
+	 * @param  mixed $group The value for the navigation group [optional]
+	 * @return mixed        The value for the navigation group or $this
+	 */
+	public function navigation_group( & $group = NULL)
+	{
+		is_null($group) OR $this->_navigation_group = $group;
+
+		return ( is_null($group) ? $this->_navigation_group : $this );
 	}
 
 	/**

--- a/system/cms/modules/navigation/controllers/admin_groups.php
+++ b/system/cms/modules/navigation/controllers/admin_groups.php
@@ -2,16 +2,15 @@
 /**
  * Admin_groups controller
  *
- * @author		PyroCMS Dev Team
- * @package	 PyroCMS\Core\Modules\Navigation\Controllers
+ * @author   PyroCMS Dev Team
+ * @package  PyroCMS\Core\Modules\Navigation\Controllers
  */
 class Admin_groups extends Admin_Controller
 {
-
 	/**
 	 * The current active section.
 	 *
-	 * @var int
+	 * @var string
 	 */
 	protected $section = 'groups';
 
@@ -89,8 +88,8 @@ class Admin_groups extends Admin_Controller
 		}
 
 		// Render the view
-		$this->template->navigation_group =& $navigation_group;
 		$this->template
+			->navigation_group($navigation_group)
 			->title($this->module_details['name'], lang('nav_group_label'), lang('nav_group_create_title'))
 			->build('admin/groups/create');
 	}

--- a/system/cms/modules/navigation/views/admin/groups/create.php
+++ b/system/cms/modules/navigation/views/admin/groups/create.php
@@ -13,12 +13,12 @@
 	    <ul>
 		    <li class="even">
 			    <label for="title"><?php echo lang('nav_title_label');?> <span>*</span></label>
-			    <div class="input"><?php echo form_input('title', $navigation_group->title, 'class="text"'); ?></div>
+			    <div class="input"><?php echo form_input('title', $this->template->navigation_group()->title, 'class="text"'); ?></div>
 		    </li>
 	    
 		    <li>
 			    <label for="url"><?php echo lang('global:slug');?> <span>*</span></label>
-			    <div class="input"><?php echo form_input('abbrev', $navigation_group->abbrev, 'class="text"'); ?></div>
+			    <div class="input"><?php echo form_input('abbrev', $this->template->navigation_group()->abbrev, 'class="text"'); ?></div>
 		    </li>
 	    </ul>
 	


### PR DESCRIPTION
...oaded property

The following notice occurs under PHP 5.3.3-7+squeeze3 when attempting to add a group to the navigation system via WEB_ROOT/admin/navigation/groups/create with this branch:

Indirect modification of overloaded property Template::$navigation_group has no effect

This notice has been resolved by creating a public setter/getter function within the Template class that accesses a additional private property named _navigation_group.
