### PR TITLE
Set to NULL if buttons are not passed.

### DIFF
--- a/system/cms/libraries/Streams/drivers/Streams_cp.php
+++ b/system/cms/libraries/Streams/drivers/Streams_cp.php
@@ -79,7 +79,7 @@ class Streams_cp extends CI_Driver {
   		$data = array(
   			'stream'		=> $stream,
   			'stream_fields'	=> $stream_fields,
-  			'buttons'		=> $extra['buttons']
+  			'buttons'		=> isset($extra['buttons']) ? $extra['buttons'] : NULL,
   		);
   
  		// -------------------------------------


### PR DESCRIPTION
I missed this tiny detail. This will avoid errors if a button array is not passed.
