### PR TITLE
Fix tenary logic

### DIFF
--- a/system/cms/libraries/Streams/drivers/Streams_fields.php
+++ b/system/cms/libraries/Streams/drivers/Streams_fields.php
@@ -75,7 +75,7 @@ class Streams_fields extends CI_Driver {
 		}
 
 		// Set locked 
-		$locked = isset($locked) and $locked === true ? 'yes' : 'no';
+		$locked = (isset($locked) and $locked === true) ? 'yes' : 'no';
 		
 		// Set extra
 		if ( ! isset($extra) or ! is_array($extra)) $extra = array();


### PR DESCRIPTION
Trying to add any stream fields with the 2.1 release i get

Data truncated for column 'is_locked' at row 1

the tenary logic in stream_fields results in a boolean false and insert_field will try to insert '0'
