### PR TITLE
Rename file, update path in DB

### DIFF
--- a/system/cms/modules/files/libraries/Files.php
+++ b/system/cms/modules/files/libraries/Files.php
@@ -466,7 +466,7 @@ class Files
 							  'location' => $new_location,
 							  'container' => $container);
 
-				ci()->file_m->update($file_id, array('filename' => $filename, 'name' => $new_name));
+				ci()->file_m->update($file_id, array('filename' => $filename, 'name' => $new_name, 'path' => '{{ url:site }}files/large/'.$filename));
 
 				@rename(self::$path.$file->filename, self::$path.$filename);
 


### PR DESCRIPTION
When renaming a file in the Files module, the path field in the DB was not being updated to reflect the new filename on the server. I added the new path as an additional param to the file_m update.
