### PR TITLE
Update system/cms/themes/pyrocms/views/fragments/wysiwyg.php

### DIFF
--- a/system/cms/themes/pyrocms/views/fragments/wysiwyg.php
+++ b/system/cms/themes/pyrocms/views/fragments/wysiwyg.php
@@ -1,6 +1,5 @@
-<script src="<?php echo Asset::get_filepath_js('ckeditor/ckeditor.js'); ?>"></script>
-<script src="<?php echo Asset::get_filepath_js('ckeditor/adapters/jquery.js'); ?>"></script>
-
+<script type="text/javascript" src="<?php echo BASE_URL?>system/cms/themes/pyrocms/js/ckeditor/ckeditor.js"></script>
+<script type="text/javascript" src="<?php echo BASE_URL?>system/cms/themes/pyrocms/js/ckeditor/adapters/jquery.js"></script>
 <script type="text/javascript">
 
 	var instance;


### PR DESCRIPTION
this change is because how to load the js with the new function
<script src = "<? Asset :: get_filepath_js php echo ('ckeditor / ckeditor.js');?>"> </ script> ckeditor brings problems opening in internet explorer 6 back
