### PR TITLE
Added support for processing BEFORE inserting in streams_core.

### DIFF
--- a/system/cms/modules/streams_core/models/row_m.php
+++ b/system/cms/modules/streams_core/models/row_m.php
@@ -1297,6 +1297,9 @@ class Row_m extends MY_Model {
 		// Insert data
 		// -------------------------------------
 		
+		// Is there any logic to complete before inserting?
+		if ( Events::trigger('streams_pre_insert_entry', array('stream' => $stream, 'insert_data' => $insert_data)) === false ) return false;
+		
 		if ( ! $this->db->insert($stream->stream_prefix.$stream->stream_slug, $insert_data))
 		{
 			return false;


### PR DESCRIPTION
This can be helpful for when API calls or something are needed BEFORE inserting data. 3rd party applications, CMS API calls or whatever. Kills the process if false is returned (API call reports / error failure for a possible instance).
