### PR TITLE
calling $this->add_package_path(SHARED_ADDONPATH); before parent constru...

### DIFF
--- a/system/cms/core/MY_Loader.php
+++ b/system/cms/core/MY_Loader.php
@@ -19,9 +19,9 @@ class MY_Loader extends MX_Loader {
             define('SPARKPATH', 'system/sparks/');
         }
 		
-		$this->add_package_path(SHARED_ADDONPATH);
-		
 		parent::__construct();
+		
+		$this->add_package_path(SHARED_ADDONPATH);
 	}
 
 	/**


### PR DESCRIPTION
...ct was preventing PyroCMS from loading libraries directly from /addons/shared_addons
