### PR TITLE
Looks like the old full_name var from pre-2.1.0 item was still being used...

### DIFF
--- a/system/cms/modules/users/views/admin/tables/users.php
+++ b/system/cms/modules/users/views/admin/tables/users.php
@@ -29,7 +29,7 @@
 							<?php if ($link_profiles) : ?>
 								<?php echo anchor('admin/users/preview/' . $member->id, $member->display_name, 'target="_blank" class="modal-large"'); ?>
 							<?php else: ?>
-								<?php echo $member->full_name; ?>
+								<?php echo $member->display_name; ?>
 							<?php endif; ?>
 							</td>
 							<td class="collapse"><?php echo mailto($member->email); ?></td>


### PR DESCRIPTION
...here as it was causing undefined errors. Changed it to pull display_name instead.
