### PR TITLE
If your site name ended with 'admin',

### DIFF
--- a/system/cms/config/config.php
+++ b/system/cms/config/config.php
@@ -302,7 +302,7 @@ $config['global_xss_filtering'] = FALSE;
 | 'csrf_expire' = The number in seconds the token should expire.
 | 'csrf_exclude_uris' = Array of URIs which ignore CSRF checks
 */
-$config['csrf_protection'] 		= (bool) preg_match('@admin(\/.+)?$@', $_SERVER['REQUEST_URI']); // only turn it on for admin panel
+$config['csrf_protection'] 		= (bool) preg_match('@\/admin(\/.+)?$@', $_SERVER['REQUEST_URI']); // only turn it on for admin panel
 $config['csrf_token_name'] 		= 'csrf_hash_name';
 $config['csrf_cookie_name'] 	= 'csrf_cookie_name';
 $config['csrf_expire'] 			= 7200;


### PR DESCRIPTION
 CSRF protection was enabled on every page, because the regexp found it.
Now it only matches '/admin/' at the end, so it works as intended.
