### PR TITLE
Fix a typo.

### DIFF
--- a/system/cms/modules/pages/language/german/pages_lang.php
+++ b/system/cms/modules/pages/language/german/pages_lang.php
@@ -40,7 +40,7 @@ $lang['pages.current_label']               = 'Aktuelle';
 
 $lang['pages.view_label']                  = 'Ansicht';
 $lang['pages.create_label']                = 'Unterobjekt hinzuf&uuml;gen';
-$lang['pages.duplicate_label']               = 'Dublizieren';
+$lang['pages.duplicate_label']               = 'Duplizieren';
 
 // titles
 $lang['pages.create_title']                = 'Seite erstellen';


### PR DESCRIPTION
The word 'duplicate' translates to 'duplizieren' in German.
