### PR TITLE
Did it again to 2.2/develop

### DIFF
--- a/installer/sql/default.sql
+++ b/installer/sql/default.sql
@@ -67,7 +67,7 @@ INSERT INTO `{PREFIX}users` (`id`, `email`, `password`, `salt`, `group_id`, `ip_
 
 CREATE TABLE IF NOT EXISTS `core_users` (
   `id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `email` varchar(40) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `email` varchar(60) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `password` varchar(100) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `salt` varchar(6) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `group_id` int(11) DEFAULT NULL,

--- a/system/cms/config/migration.php
+++ b/system/cms/config/migration.php
@@ -23,7 +23,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 97;
+$config['migration_version'] = 98;
 
 /*
 |--------------------------------------------------------------------------

--- a/system/cms/config/mimes.php
+++ b/system/cms/config/mimes.php
@@ -134,6 +134,8 @@ $mimes = array('hqx'	=>	array('application/mac-binhex40', 'application/mac-binhe
 				'ac3'   =>	'audio/ac3',
 				'flac'  =>	'audio/x-flac',
 				'ogg'   =>	'audio/ogg',
+				'pages' =>      'application/zip',
+				'numbers' =>    'application/zip',
 			);
 
 

--- a/system/cms/migrations/098_Increase_file_extension_and_email_length.php
+++ b/system/cms/migrations/098_Increase_file_extension_and_email_length.php
@@ -1,0 +1,41 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Increase_file_extension_and_email_length extends CI_Migration
+{
+	public function up()
+	{
+        $this->dbforge->modify_column('files', array(
+                'extension' => array('type' => 'VARCHAR', 'constraint' => 10,)
+            )
+        );
+
+        $this->db->set_dbprefix('core_');
+        $this->dbforge->modify_column('users', array(
+            'email' => array('type' => 'VARCHAR',
+                             'constraint' => 60,
+                             'null' => FALSE,
+                             'default' => '')
+            )
+        );
+        $this->db->set_dbprefix(SITE_REF . '_');
+    }
+
+	public function down()
+	{
+        $this->dbforge->modify_column('files', array(
+            'extension' => array('type' => 'VARCHAR', 'constraint'  => 5)
+            )
+        );
+
+        $this->db->set_dbprefix('core_');
+        $this->dbforge->modify_column('users', array(
+                'email' => array('type' => 'VARCHAR',
+                                 'constraint' => 40,
+                                 'null' => FALSE,
+                                 'default' => '')
+            )
+        );
+
+        $this->db->set_dbprefix(SITE_REF . '_');
+    }
+}

--- a/system/cms/modules/files/config/files.php
+++ b/system/cms/modules/files/config/files.php
@@ -5,7 +5,7 @@ $config['files:path'] = UPLOAD_PATH . 'files/';
 $config['files:allowed_file_ext'] = array(
 	'a'	=> array('mpga', 'mp2', 'mp3', 'ra', 'rv', 'wav'),
 	'v'	=> array('mpeg', 'mpg', 'mpe', 'mp4', 'flv', 'qt', 'mov', 'avi', 'movie'),
-	'd'	=> array('pdf', 'xls', 'ppt', 'pptx', 'txt', 'text', 'log', 'rtx', 'rtf', 'xml', 'xsl', 'doc', 'docx', 'xlsx', 'word', 'xl', 'csv'),
+	'd'	=> array('pdf', 'xls', 'ppt', 'pptx', 'txt', 'text', 'log', 'rtx', 'rtf', 'xml', 'xsl', 'doc', 'docx', 'xlsx', 'word', 'xl', 'csv', 'pages', 'numbers'),
 	'i'	=> array('bmp', 'gif', 'jpeg', 'jpg', 'jpe', 'png', 'tiff', 'tif'),
 	'o'	=> array('psd', 'gtar', 'swf', 'tar', 'tgz', 'xhtml', 'zip', 'css', 'html', 'htm', 'shtml')
 );

--- a/system/cms/modules/files/details.php
+++ b/system/cms/modules/files/details.php
@@ -85,7 +85,7 @@ class Module_Files extends Module {
 				'filename' => array('type' => 'VARCHAR', 'constraint' => 255,),
 				'path' => array('type' => 'VARCHAR', 'constraint' => 255, 'default' => ''),
 				'description' => array('type' => 'TEXT',),
-				'extension' => array('type' => 'VARCHAR', 'constraint' => 5,),
+				'extension' => array('type' => 'VARCHAR', 'constraint' => 10,),
 				'mimetype' => array('type' => 'VARCHAR', 'constraint' => 50,),
 				'width' => array('type' => 'INT', 'constraint' => 5, 'null' => true,),
 				'height' => array('type' => 'INT', 'constraint' => 5, 'null' => true,),


### PR DESCRIPTION
extension length from 5 to 10 because of 'pages' and 'numbers' valid file extensions. Also added these as document types.

Also increased core_users email address length to 60, bc it was 60 in 'default' table, so it is now consistent :)
Added migrations regard to this changes.
Fixes #1493.

However I tested it, please check it before commit, as I don't know the system very well yet, so I might miss something!
