### PR TITLE
Installer Strict Standard Error

### DIFF
--- a/installer/index.php
+++ b/installer/index.php
@@ -186,7 +186,8 @@
 	define('FCPATH', str_replace(SELF, '', __FILE__));
 	
 	// Name of the "system folder"
-	define('SYSDIR', end(explode('/', trim(BASEPATH, '/'))));
+	$list_sysdir_parts = explode('/', trim(BASEPATH, '/'));
+	define('SYSDIR', end($list_sysdir_parts));
 
 	// The path to the "application" folder
 	define('APPPATH', $application_folder.'/');


### PR DESCRIPTION
fix a bug causing : 
Strict standards: Only variables should be passed by reference in ...\installer\index.php on line 189
