### PR TITLE
Bug in username generation

### DIFF
--- a/system/cms/modules/users/controllers/users.php
+++ b/system/cms/modules/users/controllers/users.php
@@ -309,14 +309,13 @@ class Users extends Public_Controller
 
 					$username_base = $username;
 
-					do
+					while ($this->db->where('username', $username)
+						->count_all_results('users') > 0)
 					{
 						$username = $username_base.$i;
 
 						++$i;
 					}
-					while ($this->db->where('username', $username)
-						->count_all_results('users') > 0);
 				}
 				else
 				{


### PR DESCRIPTION
My pull request #1557 introduced a new bug into user name generation: Now the normal user name won’t even be tried, instead name generation starts with `first.last1`.

This one really fixes user name generation :)
