### PR TITLE
Fixed bug for parsing attribute contents with escaped quotes.

### DIFF
--- a/system/cms/libraries/Lex/Parser.php
+++ b/system/cms/libraries/Lex/Parser.php
@@ -774,12 +774,12 @@ class Lex_Parser
 		$parameters = $this->inject_extractions($parameters, '__param_str');
 		$this->in_condition = false;
 
-		if (preg_match_all('/(.*?)\s*=\s*(\'|"|&#?\w+;)(.*?)\2/s', trim($parameters), $matches))
+		if (preg_match_all('/(.*?)\s*=\s*(\'|"|&#?\w+;)(.*?)(?<!\\\\)\2/s', trim($parameters), $matches))
 		{
 			$return = array();
 			foreach ($matches[1] as $i => $attr)
 			{
-				$return[trim($matches[1][$i])] = $matches[3][$i];
+				$return[trim($matches[1][$i])] = stripslashes($matches[3][$i]);
 			}
 
 			return $return;


### PR DESCRIPTION
Originally from:

https://github.com/happyninjas/lex/commit/ff9aa30554fce47a8bfb6dc7c94143afc2fd8f93
