### PR TITLE
Row_m::get_rows() do not use the second parameter. In addition the origi...

### DIFF
--- a/system/cms/libraries/Streams/drivers/Streams_entries.php
+++ b/system/cms/libraries/Streams/drivers/Streams_entries.php
@@ -125,17 +125,12 @@ class Streams_entries extends CI_Driver {
 
 		if ($params['paginate'] == 'yes' and ( ! isset($params['limit']) or ! is_numeric($params['limit']))) $params['limit'] = 25;
 				
-		// -------------------------------------
-		// Get Stream Fields
-		// -------------------------------------
-				
-		$this->fields =$CI->streams_m->get_stream_fields($stream->id);
 
 		// -------------------------------------
 		// Get Rows
 		// -------------------------------------
 
-		$rows = $CI->row_m->get_rows($params, $this->fields, $stream);
+		$rows = $CI->row_m->get_rows($params, null, $stream);
 		
 		$return['entries'] = $rows['rows'];
 				


### PR DESCRIPTION
...nal  ' $this->fields = $CI->streams_m->get_stream_fields($stream->id); ' line of code was buggy. In fact the '$this->fields' var remains null because it calls the parent class __set magic method which prevent the assignation logic. I think the Row_m::get_rows should be refactored to remove the second parameter.
