### PR TITLE
Add CI Pagination library "display_pages" option support

### DIFF
--- a/system/cms/libraries/Streams/drivers/Streams_entries.php
+++ b/system/cms/libraries/Streams/drivers/Streams_entries.php
@@ -57,25 +57,26 @@ class Streams_entries extends CI_Driver {
 	 * @var		array
 	 */
 	public $pagination_config = array(
-			'num_links'			=> 3,
+			'num_links'		=> 3,
 			'full_tag_open'		=> '<p>',
 			'full_tag_close'	=> '</p>',
 			'first_link'		=> 'First',
 			'first_tag_open'	=> '<div>',
 			'first_tag_close'	=> '</div>',
-			'last_link'			=> 'Last',
+			'last_link'		=> 'Last',
 			'last_tag_open'		=> '<div>',
 			'last_tag_close'	=> '</div>',
-			'next_link'			=> '&gt;',
+			'next_link'		=> '&gt;',
 			'next_tag_open'		=> '<div>',
 			'next_tag_close'	=> '</div>',
-			'prev_link'			=> '&lt;',
+			'prev_link'		=> '&lt;',
 			'prev_tag_open'		=> '<div>',
 			'prev_tag_close'	=> '</div>',
 			'cur_tag_open'		=> '<span>',
 			'cur_tag_close'		=> '</span>',
 			'num_tag_open'		=> '<div>',
-			'num_tag_close'		=> '</div>'
+			'num_tag_close'		=> '</div>',
+			'display_pages'		=> true
 	);
 
 	// --------------------------------------------------------------------------


### PR DESCRIPTION
add the "display_pages" pagination_config option. It was supported by CI but not implemented within the Stream_entries pagination wrapper system. This option, when setted to false, allow to not display page number, but only 'next' and 'prev' arrows.
