### PR TITLE
Change pagination default config array. the full_tag_open and full_tag_close opt...

### DIFF
--- a/system/cms/libraries/Streams/drivers/Streams_entries.php
+++ b/system/cms/libraries/Streams/drivers/Streams_entries.php
@@ -58,8 +58,8 @@ class Streams_entries extends CI_Driver {
 	 */
 	public $pagination_config = array(
 			'num_links'			=> 3,
-			'full_tag_open'		=> '<p>',
-			'full_tag_close'	=> '</p>',
+			'full_tag_open'		=> '<div>',
+			'full_tag_close'	=> '</div>',
 			'first_link'		=> 'First',
 			'first_tag_open'	=> '<div>',
 			'first_tag_close'	=> '</div>',


### PR DESCRIPTION
...ions can not be set to '<p>' if it contains '<div>' tags... (the '<p><div></div></p>' will be transform by the web browser to '<p></p><div></div><p></p>')
