### PR TITLE
2.2/develop: avoid having a negative offset returned from pagination helper

### DIFF
--- a/system/cms/helpers/pagination_helper.php
+++ b/system/cms/helpers/pagination_helper.php
@@ -40,6 +40,9 @@ if ( ! function_exists('create_pagination'))
 		));
 
 		$offset = $limit * ($current_page - 1);
+		
+		//avoid having a negative offset
+		if ($offset < 0) $offset = 0;
 
 		return array(
 			'current_page' => $current_page,


### PR DESCRIPTION
In some cases the offset value returned from the pagination helper is a negative number, this helps to avoid that.
