### PR TITLE
Making sure the navigation model is loaded before the call to pyrocache

### DIFF
--- a/system/cms/widgets/navigation/navigation.php
+++ b/system/cms/widgets/navigation/navigation.php
@@ -118,6 +118,9 @@ class Widget_Navigation extends Widgets
 				'is_secure' => IS_SECURE,
 			)
 		);
+
+		// Load the navigation model from the navigation module.
+		$this->load->model('navigation/navigation_m');
 		
 		$links = $this->pyrocache->model('navigation_m', 'get_link_tree', $params, Settings::get('navigation_cache'));
 


### PR DESCRIPTION
Currently this is causing a warning. There was a previous bug in this (using $group instead of $option['group']) but that has been fixed in the latest version by the looks of things.
