### PR TITLE
Fix error message when loading a page that triggers a 404

### DIFF
--- a/system/cms/modules/pages/plugin.php
+++ b/system/cms/modules/pages/plugin.php
@@ -23,7 +23,7 @@ class Plugin_Pages extends Plugin
 		$id		= $this->attribute('id');
 		$page	= $this->pyrocache->model('page_m', 'get', array($id));
 
-		return site_url($page ? $page['uri'] : '');
+		return site_url($page ? $page->uri : '');
 	}
 
 	/**


### PR DESCRIPTION
Fixes 'Fatal error: Cannot use object of type stdClass as array in /system/cms/modules/pages/plugin.php on line 26'
