### PR TITLE
Fields should be limited to the applicable namespace we are working in. ...

### DIFF
--- a/system/cms/modules/streams_core/models/fields_m.php
+++ b/system/cms/modules/streams_core/models/fields_m.php
@@ -83,8 +83,11 @@ class Fields_m extends CI_Model {
      * @param	int offset
      * @return	obj
      */
-    public function get_all_fields()
+    public function get_all_fields($namespace = false)
 	{
+		// Limit to namespace
+		if ( $namespace ) $this->db->where('field_namespace', $namespace);
+		
 		$obj = $this->db->order_by('field_name', 'asc')->get($this->table);
 		
 		$fields = $obj->result_array();


### PR DESCRIPTION
...Duplicate slugged fields will shit here since slugs / fields don't have to be unique across namespaces and everything is keyed by slug. This is part 1 / 2.

Perfect example is I have two fields in two namespaces with two setups / types both named Status (status) and only the latter is returned due to the key indexing here..
