### PR TITLE
Add newline after my addition to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ It's strongly recommended that you download the [git-flow client](https://github
 * [Eric Barnes](http://ericlbarnes.com/)
 * [Stephen Cozart](http://twitter.com/stephencozart)
 * [Matt Frost](http://shortwhitebaldguy.com)
+
 Think you should be on this list? Add yourself in the next pull request you submit.
 
 [All Contributors](https://github.com/pyrocms/pyrocms/contributors)


### PR DESCRIPTION
Forgot the newline after my name/link in the readme, it was all goofy looking, this should fix it.
