### PR TITLE
fixed redirect after login

### DIFF
--- a/system/cms/modules/users/controllers/users.php
+++ b/system/cms/modules/users/controllers/users.php
@@ -121,7 +121,7 @@ class Users extends Public_Controller
 			}
 
 			// Don't allow protocols or cheeky requests
-			if (strpos($redirect_to, ':') !== FALSE)
+			if (strpos($redirect_to, ':') !== FALSE and strpos($redirect_to, site_url()) !== 0)
 			{
 				// Just login to the homepage
 				redirect('');


### PR DESCRIPTION
The redirect after login is broken at the moment, as the login form uses this:

``` html
<input type="hidden" name="redirect_to" value="{{ url:current }}" />
```

So the redirect_to contains an absolute url, which is then ignored by the login controller.

This is a fix.
