### PR TITLE
styling of db error messages

### DIFF
--- a/system/cms/errors/error_db.php
+++ b/system/cms/errors/error_db.php
@@ -24,12 +24,17 @@ font-size:			14px;
 color:				#990000;
 margin: 			0 0 4px 0;
 }
+
+#message {
+white-space: 		pre-wrap;
+font-family: 		Consolas, monospae;
+}
 </style>
 </head>
 <body>
 	<div id="content">
 		<h1><?php echo $heading; ?></h1>
-		<?php echo $message; ?>
+		<div id="message"><?php echo $message; ?></div>
 	</div>
 </body>
 </html>


### PR DESCRIPTION
The db error messages are not in a &lt;pre>, which makes the queries really hard to read when they get longer. This is shame since codeigniter actually formats them with newlines.

Adding them in a &lt;pre> causes other problems, as it disables line-wrapping and long queries will be unreadable again.

This fixes/avoids both these problems.
