### PR TITLE
Fixed form validation in MY_Model::insert_many()

### DIFF
--- a/system/cms/core/MY_Model.php
+++ b/system/cms/core/MY_Model.php
@@ -295,7 +295,7 @@ class MY_Model extends CI_Model
 		{
 			if ($skip_validation === FALSE)
 			{
-				if ( ! $this->_run_validation($data))
+				if ( ! $this->_run_validation($row))
 				{
 					$ids[] = FALSE;
 


### PR DESCRIPTION
The validation function called in `MY_Model:insert_many()` needs to run on the single rows, not the whole array.

Cheers to Michael Wignail who actually found the bug and did this fix
