### PR TITLE
minor fix for installer

### DIFF
--- a/installer/libraries/Module_import.php
+++ b/installer/libraries/Module_import.php
@@ -26,6 +26,7 @@ class Module_import {
 		// Any dupes are generic so we shouldn't run into any 
 		// meaningful conflicts.
 		$this->ci->load->add_package_path(PYROPATH);
+		$this->ci->load->add_package_path(SHARED_ADDONPATH);
 
 		$db['hostname'] = $this->ci->session->userdata('hostname');
 		$db['username'] = $this->ci->session->userdata('username');


### PR DESCRIPTION
I’m not sure if this is a bug or not:
The installer tries to install all modules in the addons folders. So it runs the respective install() functions. But they are not run in the environment you would expect them to be run in (= the environment they run in when you click "install" in the admin panel). So they can not access a lot of other libraries etc.

This change is only a minor fix for this issue, but at least allows the install() function to load libraries in the shared_addons folder.
