### PR TITLE
Fixed the PHP warning in Create categories popup.

### DIFF
--- a/system/cms/modules/blog/controllers/admin_categories.php
+++ b/system/cms/modules/blog/controllers/admin_categories.php
@@ -224,6 +224,7 @@ class Admin_Categories extends Admin_Controller {
 	 */
 	public function create_ajax()
 	{
+		$category = new stdClass();
 		// Loop through each validation rule
 		foreach ($this->validation_rules as $rule)
 		{


### PR DESCRIPTION
Issue URL: https://github.com/pyrocms/pyrocms/issues/1703
