### PR TITLE
Added group level Control Panel access flag

### DIFF
--- a/system/cms/config/migration.php
+++ b/system/cms/config/migration.php
@@ -23,7 +23,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 101;
+$config['migration_version'] = 102;
 
 /*
 |--------------------------------------------------------------------------

--- a/system/cms/core/Admin_Controller.php
+++ b/system/cms/core/Admin_Controller.php
@@ -24,6 +24,9 @@ class Admin_Controller extends MY_Controller {
 	{
 		parent::__construct();
 
+		// Load resources
+		$this->load->model('groups/group_m');
+
 		// Load the Language files ready for output
 		$this->lang->load('admin');
 		$this->lang->load('buttons');
@@ -108,21 +111,22 @@ class Admin_Controller extends MY_Controller {
 			return TRUE;
 		}
 
-		// Well they at least better have permissions!
-		if ($this->current_user)
-		{
-			// We are looking at the index page. Show it if they have ANY admin access at all
-			if ($current_page == 'admin/index' && $this->permissions)
-			{
-				return TRUE;
-			}
+		$group = $this->group_m->get_by('id', $this->current_user->group_id);
 
-			// Check if the current user can view that page
-			return array_key_exists($this->module, $this->permissions);
+		// If group control panel access is not given, deny access
+		if (!$group->has_cp_access) 
+		{
+			return FALSE;
 		}
 
-		// god knows what this is... erm...
-		return FALSE;
+		// We are looking at the index page. Show it if their group has admin access and if they have ANY permissions at all
+		if ($current_page == 'admin/index' && $this->permissions)
+		{
+			return TRUE;
+		}
+
+		// Check if the current user can view that page
+		return  array_key_exists($this->module, $this->permissions);
 	}
 
 }

--- a/system/cms/migrations/102_Add_cp_access_flag_to_groups.php
+++ b/system/cms/migrations/102_Add_cp_access_flag_to_groups.php
@@ -1,0 +1,16 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Add_cp_access_flag_to_groups extends CI_Migration
+{
+	public function up()
+	{
+		$this->dbforge->add_column('groups', array(
+			'has_cp_access' => array('type' => 'BOOLEAN', 'null' => false, 'default' => 1)
+		));
+	}
+
+	public function down()
+	{
+		$this->dbforge->drop_column('groups', 'has_cp_access');
+	}
+}

--- a/system/cms/modules/groups/language/english/group_lang.php
+++ b/system/cms/modules/groups/language/english/group_lang.php
@@ -1,23 +1,24 @@
 <?php defined('BASEPATH') OR exit('No direct script access allowed');
 
 // labels
-$lang['groups.title']					= 'Title';
-$lang['groups.name']				    = 'Name';
-$lang['groups.short_name']				= 'Short Name';
+$lang['groups.title']               = 'Title';
+$lang['groups.name']                = 'Name';
+$lang['groups.short_name']          = 'Short Name';
+$lang['groups.cp_access']           = 'Control Panel Access';
 
 // titles
-$lang['groups.index_title']             = 'List Groups';
-$lang['groups.add_title']               = 'Add Group';
-$lang['groups.edit_title']              = 'Editing Group "%s"';
+$lang['groups.index_title']         = 'List Groups';
+$lang['groups.add_title']           = 'Add Group';
+$lang['groups.edit_title']          = 'Editing Group "%s"';
 
 // messages
-$lang['groups.no_groups']               = 'No groups found.';
-$lang['groups.add_success']             = 'The group "%s" has been added.';
-$lang['groups.add_error']               = 'The group "%s" could not be added.';
-$lang['groups.edit_success']            = 'The group "%s" has been saved.';
-$lang['groups.edit_error']              = 'The group "%s" could not be saved.';
-$lang['groups.delete_success']          = 'The group was deleted successfully.';
-$lang['groups.delete_error']            = 'There was an error deleting this group. You must delete all users associated with this group before deleting the group.';
-$lang['groups.already_exist_error']     = 'A groups item with the name "%s" already exists.';
+$lang['groups.no_groups']           = 'No groups found.';
+$lang['groups.add_success']         = 'The group "%s" has been added.';
+$lang['groups.add_error']           = 'The group "%s" could not be added.';
+$lang['groups.edit_success']        = 'The group "%s" has been saved.';
+$lang['groups.edit_error']          = 'The group "%s" could not be saved.';
+$lang['groups.delete_success']      = 'The group was deleted successfully.';
+$lang['groups.delete_error']        = 'There was an error deleting this group. You must delete all users associated with this group before deleting the group.';
+$lang['groups.already_exist_error'] = 'A groups item with the name "%s" already exists.';
 
 /* End of file group_lang.php */

--- a/system/cms/modules/groups/models/group_m.php
+++ b/system/cms/modules/groups/models/group_m.php
@@ -80,7 +80,8 @@ class Group_m extends MY_Model
 	{
 		return parent::insert(array(
 			'name'			=> $input['name'],
-			'description'	=> $input['description']
+			'description'	=> $input['description'],
+			'has_cp_access' => $input['has_cp_access']
 		));
 	}
 
@@ -96,7 +97,8 @@ class Group_m extends MY_Model
 	{
 		return parent::update($id, array(
 			'name'			=> $input['name'],
-			'description'	=> $input['description']
+			'description'	=> $input['description'],
+			'has_cp_access' => $input['has_cp_access']
 		));
 	}
 

--- a/system/cms/modules/groups/views/admin/form.php
+++ b/system/cms/modules/groups/views/admin/form.php
@@ -33,6 +33,23 @@
 			
 			</div>
 		</li>
+
+		<li>
+			<label for="has_cp_access"><?php echo lang('groups.cp_access');?></label>
+
+			<div class="input type-radio">
+				<?php if ( ! in_array($group->name, array('user', 'admin'))): ?>
+				<label class="inline">
+					<?php echo form_radio('has_cp_access', '1', $group->has_cp_access);?><?php echo lang('global:enabled'); ?>
+				</label> 
+				<label class="inline">
+					<?php echo form_radio('has_cp_access', '0', !$group->has_cp_access);?><?php echo lang('global:disabled'); ?>
+				</label> 							
+				<?php else: ?>
+				<?php echo lang('global:enabled'); ?>
+				<?php endif; ?>
+			</div>
+		</li>
     </ul>
 
 </div>

--- a/system/cms/modules/groups/views/admin/index.php
+++ b/system/cms/modules/groups/views/admin/index.php
@@ -4,11 +4,12 @@
 
 <section class="item">
 	<?php if ($groups): ?>
-		<table class="table-list" cellspacing="0">
+		<table class="table-list">
 			<thead>
 				<tr>
 					<th width="40%"><?php echo lang('groups.name');?></th>
-					<th><?php echo lang('groups.short_name');?></th>
+					<th width="20%"><?php echo lang('groups.short_name');?></th>
+					<th width="16%"><?php echo lang('groups.cp_access');?></th>
 					<th width="300"></th>
 				</tr>
 			</thead>
@@ -24,6 +25,7 @@
 				<tr>
 					<td><?php echo $group->description; ?></td>
 					<td><?php echo $group->name; ?></td>
+					<td><?php echo $group->has_cp_access ? 'Yes' : 'No'; ?></td>
 					<td class="actions">
 					<?php echo anchor('admin/groups/edit/'.$group->id, lang('buttons.edit'), 'class="button edit"'); ?>
 					<?php if ( ! in_array($group->name, array('user', 'admin'))): ?>

--- a/system/cms/plugins/user.php
+++ b/system/cms/plugins/user.php
@@ -91,10 +91,13 @@ class Plugin_User extends Plugin
 	 */
 	public function has_cp_permissions()
 	{
+		$this->load->model('groups/group_m');
+
 		if ($this->current_user)
 		{
-			if (!(($this->current_user->group == 'admin') OR $this->permission_m->get_group($this->current_user->group_id)))
-			{
+			$group = $this->group_m->get_by('id', $this->current_user->group_id);
+			if (!($this->current_user->group == 'admin' OR ($group->has_cp_access AND $this->permission_m->get_group($this->current_user->group_id))))
+			{				
 				return '';
 			}
 


### PR DESCRIPTION
Allows admins to control which user groups have control panel access
and which don't. Currently if you really want to prevent users from "seeing" any
part of the control panel, you wouldn't link them. However there is nothing to 
prevent them from appending /admin to the site url.
This change allows admins to control which user groups can access 
the control panel:
- Added "Control Panel Access" item to group module
  Control Panel UI (form and index)
- Added check in ADMIN_Controller for has_cp_access flag
- Load groups/group_m in ADMIN_Controller
- Added check to has_cp_permmissions plugin for has_cp_access flag
- Add DB Migration (102)
