### PR TITLE
fixed comments for modules named "news"

### DIFF
--- a/system/cms/modules/comments/helpers/comments_helper.php
+++ b/system/cms/modules/comments/helpers/comments_helper.php
@@ -146,9 +146,6 @@ function process_comment_items($comments)
 		// What did they comment on
 		switch ($comment->module)
 		{
-			case 'news': # Deprecated v1.1.0
-				$comment->module = 'blog';
-				break;
 			case 'gallery':
 				$comment->module = plural($comment->module);
 				break;


### PR DESCRIPTION
This 1.5 years old hack breaks (only a little bit) comments for modules that are called “news“. I do not know why it was introduced, but seeing that it is so old i assume it can be removed?

Rebased onto 2.2, as requested.
