### PR TITLE
Fixes object issue when isntalling modules

### DIFF
--- a/system/cms/modules/streams_core/models/streams_m.php
+++ b/system/cms/modules/streams_core/models/streams_m.php
@@ -446,9 +446,9 @@ class Streams_m extends MY_Model {
 		}
 		elseif ($by_slug and $namespace)
 		{
-			if (isset($this->streams_cache[$namespace][$stream_id]))
+			if (isset($this->streams_cache[$namespace]->$stream_id))
 			{
-				return $this->streams_cache[$namespace][$stream_id];
+				return $this->streams_cache[$namespace]->$stream_id;
 			}
 		}
 


### PR DESCRIPTION
There was an object to array error when attempting to install modules that had relationship fields and got their ID via get_streams.
