### PR TITLE
fixed non-object error on pages display plugin

### DIFF
--- a/system/cms/modules/pages/plugin.php
+++ b/system/cms/modules/pages/plugin.php
@@ -45,7 +45,7 @@ class Plugin_Pages extends Plugin
 			->row_array();
 
 		// Grab all the chunks that make up the body
-		$page->chunks = $this->db->get_where('page_chunks', array('page_id' => $page->id))->result_array();
+		$page['chunks'] = $this->db->get_where('page_chunks', array('page_id' => $page['id']))->result_array();
 		
 		$page->body = '';
 		if ($page['chunks'])


### PR DESCRIPTION
This fixed the following error: 

ERROR - 2012-08-14 12:24:46 --> Severity: Warning  --> Attempt to assign property of non-object system/cms/modules/pages/plugin.php 48

``` javascript
{{ pages:display slug="page-slug" }}
    {{ body }}
{{ /pages:display }}
```
