### PR TITLE
Have to use $stream_fields here.

### DIFF
--- a/system/cms/modules/streams_core/models/row_m.php
+++ b/system/cms/modules/streams_core/models/row_m.php
@@ -899,12 +899,12 @@ class Row_m extends MY_Model {
 				if ($return_object)
 				{
 					$row->$row_slug = $this->format_column($row_slug,
-						$row->$row_slug, $row->id, $this->all_fields[$row_slug]['field_type'], $this->all_fields[$row_slug]['field_data'], $stream, $plugin_call);
+						$row->$row_slug, $row->id, $stream_fields->$row_slug->field_type, $stream_fields->$row_slug->field_data, $stream, $plugin_call);
 				}
 				else
 				{
 					$row[$row_slug] = $this->format_column($row_slug,
-						$row[$row_slug], $row['id'], $this->all_fields[$row_slug]['field_type'], $this->all_fields[$row_slug]['field_data'], $stream, $plugin_call);
+						$row[$row_slug], $row['id'], $stream_fields->$row_slug->field_type, $stream_fields->$row_slug->field_data, $stream, $plugin_call);
 				}
 			}
 		}		


### PR DESCRIPTION
Otherwise fields with the same name could get pulled in from ALL fields.

PS - Why are ALL fields pulled? Seems excessive.
