### PR TITLE
Added events call when calling build_forms with streams_core

### DIFF
--- a/system/cms/modules/streams_core/libraries/Fields.php
+++ b/system/cms/modules/streams_core/libraries/Fields.php
@@ -362,6 +362,8 @@ class Fields
 		$fields = array();
 
 		$count = 0;
+		
+		$events_called = $this->run_field_events($stream_fields, $skips);
 
 		foreach($stream_fields as $slug => $field)
 		{


### PR DESCRIPTION
When creating your own module using the streams_core, and you want to override the default CP view for forms, and create your own, the events for each field type where not getting called. With this, now all the JS and CSS is getting called, and the functionality works perfectly.
