### PR TITLE
PHP Version is always acceptable

### DIFF
--- a/installer/libraries/installer_lib.php
+++ b/installer/libraries/installer_lib.php
@@ -132,7 +132,7 @@ class Installer_lib {
 	public function check_server($data)
 	{
 		// Check PHP
-		if ( ! $this->php_acceptable() )
+		if ( ! $this->php_acceptable($data->php_min_version) )
 		{
 			return FALSE;
 		}


### PR DESCRIPTION
Fixed a bug in installer (Any PHP version is acceptable). 
The installer would show a fail but yet allow to proceed to next step.
