### PR TITLE
Multiform support

### DIFF
--- a/system/cms/modules/streams_core/libraries/Fields.php
+++ b/system/cms/modules/streams_core/libraries/Fields.php
@@ -175,7 +175,18 @@ class Fields
 		
 		$result_id = '';
 
-		if ($this->CI->form_validation->run() === TRUE)
+		
+		$result_id = '';
+		$post = $this->CI->input->post();
+		$stream_check = true;
+		if(isset($post['stream_id']))
+		{
+			if($post['stream_id'] !=$stream->id )
+			{
+				$stream_check=false;
+			}
+		}
+		if (($this->CI->form_validation->run() === TRUE) && ($stream_check))
 		{
 			if ($method == 'new')
 			{


### PR DESCRIPTION
see here for detail : https://www.pyrocms.com/forums/topics/view/19742

ADAM : 
in the plugin of PyroStream, right here : 
system/cms/modules/streams/plugin.php

In the function form(), just after 
    if ($mode == 'edit') $hidden = array('row_edit_id' => $row->id);

you should add the line 
$hidden['stream_id']    =  $data->stream_id;
