### PR TITLE
new "Developer friendly" filter plugin (jquery)

### DIFF
--- a/system/cms/themes/pyrocms/js/admin/filter.js
+++ b/system/cms/themes/pyrocms/js/admin/filter.js
@@ -1,15 +1,9 @@
 (function($){
 
-    var filterDefaults = {
-        filter_onload: true,
-        content: '#filter-stage',
-        module: '', // the current module name
-		module_selector: 'input[name="f_module"]'
-    };
- 
+	//Filter Class Constructor
     function Filter(form, opts)
     {
-		this._opts = $.extend({}, filterDefaults, opts || {});
+		this._opts = $.extend({}, $.fn.pyroFilter.defaultsOptions, opts || {});
 		this.form = form;
         this.$form = $(form);
 		this.$content = (typeof this._opts.content === "string") ? $(this._opts.content) : this._opts.content;
@@ -149,6 +143,8 @@
         }
     };
 
+
+    //JQuery plugin
     $.fn.pyroFilter = function (method) {
 
             var $fn = this.data('pyrofilter');
@@ -174,6 +170,15 @@
             }    
 
     };
+
+    $.fn.pyroFilter.defaultsOptions = {
+        filter_onload: true,
+        content: '#filter-stage',
+        module: '', // the current module name
+		module_selector: 'input[name="f_module"]'
+    };
+ 
+
 })(jQuery);
 
 //Default init for core modules


### PR DESCRIPTION
I will submit the docs in due time.

Until then:

Here is a new jquery plugin for filtering which takes the place of pyro.filter
It is a lot more friendly for third-party development, here are some examples/usages:

``` javascript


//setup new defaults for the filter plugin
$.fn.pyroFilter.defaultsOptions = {
    filter_onload: true,
    content: '#filter-stage',
    module: '',
    module_query: 'input[name="f_module"]'
};

//override global defaults
$.fn.pyroFilter.defaultsOptions.filter_onload = true;

//init plugin
$('#filters form').pyroFilter({filter_onload:false});

//refresh filter results (trigger change)
$('#filters form').pyroFilter('refresh');

// fire custom filter
var form_data = {};
$('#filters form').pyroFilter('do_filter', form_data, url);

// Get and instance
var instance = $('#filters form').pyroFilter('getInstance');

//instance now holds all the methods from our plugin
instance.refresh();
instance.do_filter(form_data, url);
```
