### PR TITLE
Remove attr for Format plugin

### DIFF
--- a/system/cms/plugins/format.php
+++ b/system/cms/plugins/format.php
@@ -29,9 +29,9 @@ class Plugin_format extends Plugin
 	{
 		$this->load->helper('markdown');
 
-		$content = $this->attribute('content', $this->content());
+		$content = $this->content();
 
-		return parse_markdown(trim($content, "\n"));
+		return parse_markdown(trim($content));
 	}
 	
 	
@@ -53,9 +53,9 @@ class Plugin_format extends Plugin
 	{
 		$this->load->library('textile');
 
-		$content = $this->attribute('content', $this->content());
+		$content = $this->content();
 
-		return $this->textile->TextileThis(trim($content, "\n"));
+		return $this->textile->TextileThis(trim($content));
 	}
 
 


### PR DESCRIPTION
Apparently I can't use {{ tags }} to handle normal AND looping tags in
same function. So lets remove the `content` attribtue since it's
unnecessary anyway.
