### PR TITLE
Logo link

### DIFF
--- a/system/cms/themes/pyrocms/views/admin/partials/header.php
+++ b/system/cms/themes/pyrocms/views/admin/partials/header.php
@@ -6,7 +6,7 @@
 	
 	<div class="wrapper">
 		<div id="logo">
-			<?php echo anchor('admin', $this->settings->site_name, 'target="_blank"'); ?>
+			<?php echo anchor('', $this->settings->site_name, 'target="_blank"'); ?>
 		</div>
 	
 		<nav id="primary">


### PR DESCRIPTION
I have removed the 'admin' part in the anchor to allow usrs to see the frontend site when clicked, just as happened in the other version.
With the admin label in the anchor users just reload the same page.
