### PR TITLE
Fixes an issue with invalid users in streams_core

### DIFF
--- a/system/cms/modules/streams_core/field_types/user/field.user.php
+++ b/system/cms/modules/streams_core/field_types/user/field.user.php
@@ -120,16 +120,23 @@ class Field_user
 		
 		$user = $this->CI->user_m->get(array('id' => $input));
 
-		$return = array(
-			'user_id'			=> $user->user_id,
-			'display_name'		=> $user->display_name,
-			'email'				=> $user->email,
-			'username'			=> $user->username,
-		);
-		
-		$this->cache[$input] = $return;
-		
-		return $return;
+		// Ensure the user was found
+		if ( ! empty($user) )
+		{
+
+			$return = array(
+				'user_id'			=> $user->user_id,
+				'display_name'		=> $user->display_name,
+				'email'				=> $user->email,
+				'username'			=> $user->username,
+			);
+			
+			$this->cache[$input] = $return;
+			
+			return $return;
+		}
+
+		return false;
 	}
 
 }


### PR DESCRIPTION
We found an issue with the user field type where it would presume that a user would be found, so if a user was deleted or an ID was changed it would start throwing the below warnings on lines 128-131:

A PHP Error was encountered
Severity: Notice
Message: Trying to get property of non-object
Filename: user/field.user.php
Line Number: 129

It now performs a check to ensure that the $user array is not empty and returns false if it is.
