### PR TITLE
fix "update_stream" feature

### DIFF
--- a/system/cms/libraries/Streams/drivers/Streams_streams.php
+++ b/system/cms/libraries/Streams/drivers/Streams_streams.php
@@ -137,7 +137,6 @@ class Streams_streams extends CI_Driver {
 		if ( ! $str_id) $this->log_error('invalid_stream', 'update_stream');
 		
 		$data['stream_slug'] = $stream;
-		$data['stream_prefix'] = isset($data['stream_prefix']) ? $data['stream_prefix'] : NULL;
 
 		return $this->CI->streams_m->update_stream($str_id, $data);
 	}

--- a/system/cms/modules/streams_core/models/streams_m.php
+++ b/system/cms/modules/streams_core/models/streams_m.php
@@ -268,7 +268,7 @@ class Streams_m extends MY_Model {
 		// See if the stream slug is different
 		$stream = $this->get_stream($stream_id);
 		
-		if ($stream->stream_slug != $data['stream_slug'] or $stream->stream_prefix != $data['stream_prefix'])
+		if ($stream->stream_slug != $data['stream_slug'] or (isset($data['stream_prefix']) and $stream->stream_prefix != $data['stream_prefix']))
 		{
 			// Use the right DB prefix
 			if (isset($data['stream_prefix']))


### PR DESCRIPTION
Fix "update_stream" method.  Before we could not update a stream without passing a "stream_prefix" value to the updated_data array. ( It was causing a "this stream slug already exist" error ).
