### PR TITLE
Cleanup Admin JavaScript and maybe an new feature

### DIFF
--- a/system/cms/themes/pyrocms/views/admin/partials/metadata.php
+++ b/system/cms/themes/pyrocms/views/admin/partials/metadata.php
@@ -20,19 +20,24 @@ Asset::js(array('codemirror/codemirror.js',
 <?php endif; ?>
 
 <script type="text/javascript">
-	pyro = { 'lang' : {} };
-	var APPPATH_URI					= "<?php echo APPPATH_URI;?>";
-	var SITE_URL					= "<?php echo rtrim(site_url(), '/').'/';?>";
-	var BASE_URL					= "<?php echo BASE_URL;?>";
-	var BASE_URI					= "<?php echo BASE_URI;?>";
-	var UPLOAD_PATH					= "<?php echo UPLOAD_PATH;?>";
-	var DEFAULT_TITLE				= "<?php echo addslashes($this->settings->site_name); ?>";
-	pyro.admin_theme_url			= "<?php echo BASE_URL . $this->admin_theme->path; ?>";
-	pyro.apppath_uri				= "<?php echo APPPATH_URI; ?>";
-	pyro.base_uri					= "<?php echo BASE_URI; ?>";
-	pyro.lang.remove				= "<?php echo lang('global:remove'); ?>";
-	pyro.lang.dialog_message 		= "<?php echo lang('global:dialog:delete_message'); ?>";
-	pyro.foreign_characters			= <?php echo json_encode(accented_characters()); ?>
+    pyro = {
+        lang:{
+            remove:"<?php echo lang('global:remove'); ?>",
+            dialog_message:"<?php echo lang('global:dialog:delete_message'); ?>"
+        },
+        admin_theme_url:"<?php echo BASE_URL . $this->admin_theme->path; ?>",
+        apppath_uri:"<?php echo APPPATH_URI; ?>",
+        base_uri:"<?php echo BASE_URI; ?>",
+        csrf_cookie_name:"<?php echo config_item('cookie_prefix') . config_item('csrf_cookie_name'); ?>",
+        foreign_characters:<?php echo json_encode(accented_characters()); ?>,
+        module: "<?php echo $this->module; ?>"
+    };
+    var APPPATH_URI = "<?php echo APPPATH_URI;?>";
+    var SITE_URL = "<?php echo rtrim(site_url(), '/') . '/';?>";
+    var BASE_URL = "<?php echo BASE_URL;?>";
+    var BASE_URI = "<?php echo BASE_URI;?>";
+    var UPLOAD_PATH = "<?php echo UPLOAD_PATH;?>";
+    var DEFAULT_TITLE = "<?php echo addslashes($this->settings->site_name); ?>";
 </script>
 
 <?php Asset::css(array('plugins.css', 'jquery/colorbox.css', 'codemirror.css')); ?>


### PR DESCRIPTION
I cleaned the admin javascript. Also added the module parameter. 

I think you should bring the "constants" (APPPATH_URI, SITE_URL, etc.) also to the pyro object. Keep all pyro vars combined. But I think this should be discussed first. Also consider the possibility of an extend function to the pyro object like jquery does. I think this will give javascript devlopers the chance to add functions to PyroCMS.

If I dream on, PyroCMS gets a admin_javascript controller. Where one can send ajax requests to, loading the things they want like Phil did with the rest controller. 

Option 2: a javascript module, that loads a javascript.php in the root of another module like an events or plugin file.

I think, if you do this right, ajax request to PyroCMS will be a lot easier, they don't ruin your controller files, and you can built in default validation for an ajax request.

Shoot at my idea!
