### PR TITLE
Overloading widgets display.php from theme

### DIFF
--- a/system/cms/modules/widgets/libraries/Widgets.php
+++ b/system/cms/modules/widgets/libraries/Widgets.php
@@ -199,7 +199,9 @@ class Widgets {
 
 		$data['options'] = $options;
 
-		return $this->load_view('display', $data);
+		$overload = file_exists($this->template->get_views_path().'widgets/'.$name.EXT) ? $name : FALSE;
+
+		return $this->load_view('display', $data, $overload);
 	}
 
 	function render_backend($name, $saved_data = array())
@@ -474,10 +476,19 @@ class Widgets {
 		}
 	}
 
-	protected function load_view($view, $data = array())
+	protected function load_view($view, $data = array(), $overload = FALSE)
 	{
-		$path = isset($this->_widget->path) ? $this->_widget->path : $this->path;
+		if ($overload !== FALSE)
+		{
+			return $this->parser->parse_string($this->load->_ci_load(array(
+				'_ci_path'		=> $this->template->get_views_path().'widgets/' . $overload . EXT,
+				'_ci_vars'		=> $data,
+				'_ci_return'	=> TRUE
+			)), array(), TRUE);
+		}
 
+		$path = isset($this->_widget->path) ? $this->_widget->path : $this->path;
+		
 		return $view == 'display'
 
 			? $this->parser->parse_string($this->load->_ci_load(array(


### PR DESCRIPTION
I've just tested this functionnality on fresh install.
Tested on 2.1.4. No benchmarks done. And finally, I've no idea if this
functionnality has been integrated by an optimal way.

Overload your widget by placing a copy of the concerned display.php
file in a "widgets" folder in your current theme "views" folder. And
rename display.php by the widget name.

Ex for overloading "blog_categories" widget.
Copy "modules > blog > widgets > blog_categories > views > display.php"
in "<your-theme> > views > widgets".
Rename it in "blog_categories.php". Enjoy!
