### PR TITLE
Add the ability to supress form_build redirect

### DIFF
--- a/system/cms/modules/streams_core/libraries/Fields.php
+++ b/system/cms/modules/streams_core/libraries/Fields.php
@@ -235,8 +235,16 @@ class Fields
 				}
 			}
 			
-			// Redirect and replace -id- with the result ID
-			redirect(str_replace('-id-', $result_id, $extra['return']));
+			// If return url is set, redirect and replace -id- with the result ID
+			// Otherwise return id
+			if ($extra['return'])
+			{
+				redirect(str_replace('-id-', $result_id, $extra['return']));
+			}
+			else
+			{
+				return $result_id;
+			}
 		}
 		
 		// -------------------------------------


### PR DESCRIPTION
By passing false in as the extra[return] field this change will supress the redirect and return the ID being created/updated. By doing this a script can now perform extra processing before redirecting a user to the next/current page.
