### PR TITLE
Allow dashes in variable name for the Lex Parser

### DIFF
--- a/system/cms/libraries/Lex/Parser.php
+++ b/system/cms/libraries/Lex/Parser.php
@@ -554,7 +554,7 @@ class Lex_Parser
 		}
 		$glue = preg_quote($this->scope_glue, '/');
 
-		$this->variable_regex = $glue === '\\.' ? '[a-zA-Z0-9_'.$glue.']+' : '[a-zA-Z0-9_\.'.$glue.']+';
+		$this->variable_regex = $glue === '\\.' ? '[a-zA-Z0-9_\-'.$glue.']+' : '[a-zA-Z0-9_\-\.'.$glue.']+';
 		$this->callback_name_regex = $this->variable_regex.$glue.$this->variable_regex;
 		$this->variable_loop_regex = '/\{\{\s*('.$this->variable_regex.')\s*\}\}(.*?)\{\{\s*\/\1\s*\}\}/ms';
 		$this->variable_tag_regex = '/\{\{\s*('.$this->variable_regex.')\s*\}\}/m';


### PR DESCRIPTION
this small change allows dashes to be included in variable names.
example: 
`{{ fields:fld-1 }}`
