### PR TITLE
Fixes #1954: Auto PYRO_ENV detection in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,6 @@
 # Multiple Environment config
 # Set this to development, staging or production
+# SetEnv PYRO_ENV production
 
 <IfModule mod_rewrite.c>
 


### PR DESCRIPTION
Added options in .htaccess file (commented out by default) to allow for the .htaccess file to automatically determine and set the PYRO_ENV variable. This would allow the .htaccess file to be under version control and not be specific to the environment it is installed on.
