### PR TITLE
Fixed error in front end for blog posts

### DIFF
--- a/system/cms/modules/blog/models/blog_m.php
+++ b/system/cms/modules/blog/models/blog_m.php
@@ -94,7 +94,7 @@ class Blog_m extends MY_Model
 		// By default, dont show future posts
 		if ( ! isset($params['show_future']) || (isset($params['show_future']) && $params['show_future'] == false))
 		{
-			$this->db->where('created_on <=', now());
+			$this->db->where('blog.created_on <=', now());
 		}
 
 		// Limit the results based on 1 number or 2 (2nd is offset)


### PR DESCRIPTION
In a fresh installation if you try to access to the blog page it says that the are an ambiguos use of created_on in the where clausole.
This should fix that error.
