### PR TITLE
Theme options panel - Missing object init for $data

### DIFF
--- a/system/cms/modules/themes/controllers/admin.php
+++ b/system/cms/modules/themes/controllers/admin.php
@@ -169,6 +169,7 @@ class Admin extends Admin_Controller
 			}
 		}
 
+		$data = new stdClass();
 		$data->slug = $slug;
 		$data->options_array = $all_options;
 		$data->controller = &$this;


### PR DESCRIPTION
just added:
`$data = new stdClass();`
