### PR TITLE
Fixes an issue getting a field by slug

### DIFF
--- a/system/cms/modules/streams_core/models/fields_m.php
+++ b/system/cms/modules/streams_core/models/fields_m.php
@@ -688,9 +688,9 @@ class Fields_m extends CI_Model {
 	public function get_field_by_slug($field_slug, $field_namespace)
 	{
 		// Check for already cached value
-		if (isset($this->fields_cache['by_slug'][$field_slug]))
+		if (isset($this->fields_cache['by_slug'][$field_namespace.':'.$field_slug]))
 		{
-			return $this->fields_cache['by_slug'][$field_slug];
+			return $this->fields_cache['by_slug'][$field_namespace.':'.$field_slug];
 		}
 
 		$obj = $this->db
@@ -709,7 +709,7 @@ class Fields_m extends CI_Model {
 		$field->field_data = unserialize($field->field_data);
 
 		// Save for later use
-		$this->fields_cache['by_slug'][$field_slug] = $field;
+		$this->fields_cache['by_slug'][$field_namespace.':'.$field_slug] = $field;
 		
 		return $field;
 	}


### PR DESCRIPTION
When retrieving a stream field by its' slug there is a conflict with the
cache where it doesn't respect the namespace that a field is in and
instead returns the first instance it finds in cache. This simply
updates the cache key to use namespace:slug to avoid this conflict.
