### PR TITLE
[feature/pdo] Converting modules to use illuminate/database during installation

### DIFF
--- a/system/cms/modules/groups/details.php
+++ b/system/cms/modules/groups/details.php
@@ -77,34 +77,20 @@
 
 	public function install()
 	{
-		$this->dbforge->drop_table('groups', true);
+		$schema = $this->pdb->getSchemaBuilder();
+		$schema->drop('groups');
 
-		$tables = array(
-			'groups' => array(
-				'id' => array('type' => 'INT', 'constraint' => 11, 'auto_increment' => true, 'primary' => true,),
-				'name' => array('type' => 'VARCHAR', 'constraint' => 100,),
-				'description' => array('type' => 'VARCHAR', 'constraint' => 250, 'null' => true,),
-			),
-		);
+		$schema->create('groups',function(\Illuminate\Database\Schema\Blueprint $table) {
+			$table->increments('id');
+			$table->string('name', 100);
+			$table->string('description', 250)->nullable();
 
-		if ( ! $this->install_tables($tables))
-		{
-			return false;
-		}
+			$table->primary('id');
+		});
 
-		$groups = array(
-			array('name' => 'admin', 'description' => 'Administrator',),
-			array('name' => 'user', 'description' => 'User',),
-		);
-
-		foreach ($groups as $group)
-		{
-			if ( ! $this->db->insert('groups', $group))
-			{
-				return false;
-			}
-		}
-
+		// TODO: Something tells me there is an easier way to insert multiple records.
+		$this->pdb->table('groups')->insert(array('name' => 'admin', 'description' => 'Administrator'));
+		$this->pdb->table('groups')->insert(array('name' => 'user', 'description' => 'User'));
 		return true;
 	}
 

--- a/system/cms/modules/keywords/details.php
+++ b/system/cms/modules/keywords/details.php
@@ -64,20 +64,24 @@ class Module_Keywords extends Module {
 
 	public function install()
 	{
-		$this->dbforge->drop_table('keywords', true);
-		$this->dbforge->drop_table('keywords_applied', true);
+		$schema = $this->pdb->getSchemaBuilder();
+		$schema->drop('keywords');
 
-		return $this->install_tables(array(
-			'keywords' => array(
-				'id' => array('type' => 'INT', 'constraint' => 11, 'auto_increment' => true, 'primary' => true,),
-				'name' => array('type' => 'VARCHAR', 'constraint' => 50,),
-			),
-			'keywords_applied' => array(
-				'id' => array('type' => 'INT', 'constraint' => 11, 'auto_increment' => true, 'primary' => true,),
-				'hash' => array('type' => 'CHAR', 'constraint' => 32, 'default' => '',),
-				'keyword_id' => array('type' => 'INT', 'constraint' => 11,),
-			),
-		));
+		$schema->create('keywords',function(\Illuminate\Database\Schema\Blueprint $table) {
+			$table->increments('id');
+			$table->string('name', 50);
+			$table->primary('id');
+		});
+
+		$schema->drop('keywords_applied');
+
+		$schema->create('keywords_applied',function(\Illuminate\Database\Schema\Blueprint $table) {
+			$table->increments('id')->primary();
+			$table->string('hash', 32)->default('');
+			$table->integer('keyword_id');
+		});
+
+		return true;
 	}
 
 	public function uninstall()

--- a/system/cms/modules/redirects/details.php
+++ b/system/cms/modules/redirects/details.php
@@ -75,18 +75,19 @@ class Module_Redirects extends Module {
 
 	public function install()
 	{
-		$this->dbforge->drop_table('redirects', true);
+		$schema = $this->pdb->getSchemaBuilder();
+		$schema->drop('redirects');
 
-		$tables = array(
-			'redirects' => array(
-				'id' => array('type' => 'int', 'constraint' => 11, 'auto_increment' => true, 'primary' => true,),
-				'from' => array('type' => 'varchar', 'constraint' => 250, 'key' => 'request'),
-				'to' => array('type' => 'varchar', 'constraint' => 250,),
-				'type' => array('type' => 'int','constraint' => 3,'default' => 302),
-			),
-		);
+		$schema->create('redirects',function(\Illuminate\Database\Schema\Blueprint $table) {
+			$table->increments('id');
+			$table->string('from', 250);
+			$table->string('to', 250);
+			$table->integer('type')->default(302);
 
-		return $this->install_tables($tables);
+			$table->primary('id');
+			$table->index('from', 'request');
+		});
+		return true;
 	}
 
 	public function uninstall()

--- a/system/cms/modules/search/details.php
+++ b/system/cms/modules/search/details.php
@@ -33,24 +33,27 @@ class Module_Search extends Module {
 
 	public function install()
 	{
-		$this->dbforge->drop_table('search_index', true);
+		$schema = $this->pdb->getSchemaBuilder();
+		$schema->drop('search_index');
 
-		return $this->install_tables(array(
-			'search_index' => array(
-				'id' => array('type' => 'INT', 'unsigned' => true, 'auto_increment' => true, 'primary' => true,),
-				'title' => array('type' => 'VARCHAR', 'constraint' => 255, 'fulltext' => 'full search'),
-				'description' => array('type' => 'text', 'fulltext' => 'full search'),
-				'keywords' => array('type' => 'text', 'fulltext' => 'full search'),
-				'keyword_hash' => array('type' => 'text'),
-				'module' => array('type' => 'varchar', 'constraint' => 40, 'unique' => 'unique'),
-				'entry_key' => array('type' => 'varchar', 'constraint' => 100, 'unique' => 'unique'),
-				'entry_plural' => array('type' => 'varchar', 'constraint' => 100),
-				'entry_id' => array('type' => 'varchar', 'constraint' => 255, 'unique' => 'unique'),
-				'uri' => array('type' => 'varchar', 'constraint' => 255),
-				'cp_edit_uri' => array('type' => 'varchar', 'constraint' => 255),
-				'cp_delete_uri' => array('type' => 'varchar', 'constraint' => 255),
-			),
-		));
+		$schema->create('search_index',function(\Illuminate\Database\Schema\Blueprint $table) {
+			$table->increments('id');
+			$table->string('title', 255)->fulltext(); // TODO: I don't have an idea about this, FULLTEXT doesn't seem to be implemented in illuminate/database
+			$table->text('description')->fulltext(); // TODO: Same as above
+			$table->text('keywords')->fulltext(); // TODO: Same as above
+			$table->text('keywords_hash');
+			$table->string('module', 40);
+			$table->string('entry_key', 100);
+			$table->string('entry_plural', 100);
+			$table->string('entry_id', 255);
+			$table->string('uri', 255);
+			$table->string('cp_edit_uri', 255);
+			$table->string('cp_delete_uri', 255);
+
+			$table->primary('id');
+			$table->unique(array('module', 'entry_key', 'entry_id'));
+		});
+		return true;
 
 		/*
 		TODO Work out how to enable this search stuff for other systems

--- a/system/cms/modules/templates/details.php
+++ b/system/cms/modules/templates/details.php
@@ -71,31 +71,29 @@ class Module_Templates extends Module {
 
 	public function install()
 	{
-		$this->dbforge->drop_table('email_templates', true);
+		$schema = $this->pdb->getSchemaBuilder();
+		$schema->drop('email_templates');
 
-		$tables = array(
-			'email_templates' => array(
-				'id' => array('type' => 'INT', 'constraint' => 11, 'auto_increment' => true, 'primary' => true,),
-				'slug' => array('type' => 'VARCHAR', 'constraint' => 100, 'unique' => 'slug_lang',),
-				'name' => array('type' => 'VARCHAR', 'constraint' => 100,), // @todo rename this to 'title' to keep coherency with the rest of the modules
-				'description' => array('type' => 'VARCHAR', 'constraint' => 255,), // @todo change this to TEXT to be coherent with the rest of the modules
-				'subject' => array('type' => 'VARCHAR', 'constraint' => 255,),
-				'body' => array('type' => 'TEXT'),
-				'lang' => array('type' => 'VARCHAR', 'constraint' => 2, 'null' => true, 'unique' => 'slug_lang',),
-				'is_default' => array('type' => 'INT', 'constraint' => 1, 'default' => 0,),
-				'module' => array('type' => 'VARCHAR', 'constraint' => 50, 'default' => '',),
-			),
-		);
+		$schema->create('email_templates',function(\Illuminate\Database\Schema\Blueprint $table) {
+			$table->increments('id');
+			$table->string('slug', 100);
+			$table->string('title', 100);       // @todo rename this to 'title' to keep coherency with the rest of the modules
+			$table->string('description', 255); // @todo change this to TEXT to be coherent with the rest of the modules
+			$table->string('subject', 255);
+			$table->text('body');
+			$table->string('lang', 2)->nullable();
+			$table->boolean('is_default')->default(false);
+			$table->string('module', 50)->default('');
 
-		if ( !$this->install_tables($tables))
-		{
-			return false;
-		}
+			$table->primary('id');
+			$table->unique(array('slug', 'lang'), 'slug_lang');
+		});
 
+		$this->pdb->table('email_templates')->insert(array());
 		// Insert the default email templates
 
 		// @todo move this to the comments module
-		$this->db->insert('email_templates',array(
+		$this->pdb->table('email_templates')->insert(array(
 			'slug' => 'comments',
 			'name' => 'Comment Notification',
 			'description' => 'Email that is sent to admin when someone creates a comment',
@@ -114,7 +112,7 @@ class Module_Templates extends Module {
 		));
 
 		// @todo move this to the contact module
-		$this->db->insert('email_templates',array(
+		$this->pdb->table('email_templates')->insert(array(
 			'slug' => 'contact',
 			'name' => 'Contact Notification',
 			'description' => 'Template for the contact form',
@@ -136,7 +134,7 @@ class Module_Templates extends Module {
 		));
 
 		// @todo move this to the users module
-		$this->db->insert('email_templates',array(
+		$this->pdb->table('email_templates')->insert(array(
 			'slug' => 'registered',
 			'name' => 'New User Registered',
 			'description' => 'Email sent to the site contact e-mail when a new user registers',
@@ -152,7 +150,7 @@ class Module_Templates extends Module {
 		));
 
 		// @todo move this to the users module
-		$this->db->insert('email_templates',array(
+		$this->pdb->table('email_templates')->insert(array(
 			'slug' => 'activation',
 			'name' => 'Activation Email',
 			'description' => 'The email which contains the activation code that is sent to a new user',
@@ -170,7 +168,7 @@ class Module_Templates extends Module {
 		));
 
 		// @todo move this to the users module
-		$this->db->insert('email_templates',array(
+		$this->pdb->table('email_templates')->insert(array(
 			'slug' => 'forgotten_password',
 			'name' => 'Forgotten Password Email',
 			'description' => 'The email that is sent containing a password reset code',
@@ -184,7 +182,7 @@ class Module_Templates extends Module {
 		));
 
 		// @todo move this to the users module
-		$this->db->insert('email_templates',array(
+		$this->pdb->table('email_templates')->insert(array(
 			'slug' => 'new_password',
 			'name' => 'New Password Email',
 			'description' => 'After a password is reset this email is sent containing the new password',

--- a/system/cms/modules/variables/details.php
+++ b/system/cms/modules/variables/details.php
@@ -78,17 +78,15 @@ class Module_Variables extends Module {
 
 	public function install()
 	{
-		$this->dbforge->drop_table('variables', true);
+		$schema = $this->pdb->getSchemaBuilder();
+		$schema->drop('variables');
 
-		$tables = array(
-			'variables' => array(
-				'id' => array('type' => 'INT', 'constraint' => 11, 'auto_increment' => true, 'primary' => true,),
-				'name' => array('type' => 'VARCHAR', 'constraint' => 250, 'null' => true,),
-				'data' => array('type' => 'VARCHAR', 'constraint' => 250, 'null' => true,),
-			),
-		);
-
-		return $this->install_tables($tables);
+		$schema->create('variables',function(\Illuminate\Database\Schema\Blueprint $table) {
+			$table->increments('id')->primary();
+			$table->string('name', 250)->nullable();
+			$table->string('data', 250)->nullable();
+		});
+		return true;
 	}
 
 	public function uninstall()


### PR DESCRIPTION
The following modules where converted (results are not guaranteed though, not tested):
- groups
- keywords
- redirects
- search
- settings
- templates
- variables

Note that the modules that are using Streams are not being converted. 
Maybe the Streams library should to be converted first to use `illuminate/database`?
