### PR TITLE
Fixed bugs in helper:count

### DIFF
--- a/system/cms/plugins/helper.php
+++ b/system/cms/plugins/helper.php
@@ -98,7 +98,7 @@ class Plugin_Helper extends Plugin
 	 * Replaces whitespace in the content.
 	 * 
 	 * Usage:
-	 * {{ helper:replace replace="   " }} Ouputs all whitespace replaced by three spaces.
+	 * {{ helper:replace replace="   " }} Outputs all whitespace replaced by three spaces.
 	 *
 	 * @return string The final content string.
 	 */
@@ -148,23 +148,17 @@ class Plugin_Helper extends Plugin
 		{
 			$count[$identifier] = $this->attribute('start', 1);
 		}
-
 		// lets check to see if they're only wanting to show the count
-		if (self::$_counter_increment)
+		elseif (self::$_counter_increment)
 		{
 			// count up unless they specify to "subtract"
-			$value = ($this->attribute('mode') == 'subtract') ? $count[$identifier]-- : $count[$identifier]++;
-
-			// go ahead and increment but return an empty string
-			if (strtolower($this->attribute('return')) === 'false')
-			{
-				return '';
-			}
-			
-			return $value;
+			($this->attribute('mode') == 'subtract') ? $count[$identifier]-- : $count[$identifier]++;
 		}
 		
-		return $count[$identifier];
+		// set this back to continue counting again next time
+		self::$_counter_increment = true;
+		
+		return (strtolower($this->attribute('return')) === 'false') ? '' : $count[$identifier];
 	}
 
 	/**


### PR DESCRIPTION
There was a bug that cause the counting to stop once `show_count()` was
called. This causes a problem when you want to use the count number
multiple times in a loop.
