### PR TITLE
[2.2/develop] Fixing undefined index notice on logout

### DIFF
--- a/system/cms/modules/users/libraries/Ion_auth.php
+++ b/system/cms/modules/users/libraries/Ion_auth.php
@@ -409,7 +409,7 @@ class Ion_auth
 		delete_cookie('remember_code');
 	    }
 
-		$this->ci->session->sess_destroy();
+		$this->ci->session->sess_regenerate(true);
 
 		$this->set_message('logout_successful');
 		return true;


### PR DESCRIPTION
Logging out was producing a notice error, the session userdata was missing some indexes since the session was destroyed and not regenerated so that it would be complete.
