### PR TITLE
[2.2/develop] Fixed the Module_import::__construct() so that it writes the empty index.html

### DIFF
--- a/installer/libraries/Module_import.php
+++ b/installer/libraries/Module_import.php
@@ -5,9 +5,10 @@ define('ADDONPATH', dirname(FCPATH).'/addons/default/');
 define('SHARED_ADDONPATH', dirname(FCPATH).'/addons/shared_addons/');
 
 // All modules talk to the Module class, best get that!
-include PYROPATH .'libraries/Module'.EXT;
+include PYROPATH.'libraries/Module'.EXT;
 
-class Module_import {
+class Module_import
+{
 
 	private $ci;
 
@@ -16,7 +17,7 @@ class Module_import {
 		$this->ci =& get_instance();
 
 		// Getting our model and MY_Model class set up
-		class_exists('CI_Model', FALSE) OR load_class('Model', 'core');
+		class_exists('CI_Model', false) OR load_class('Model', 'core');
 		include(PYROPATH.'/core/MY_Model.php');
 
 		// Include some constants that modules may be looking for
@@ -32,12 +33,12 @@ class Module_import {
 		$db['username'] = $this->ci->session->userdata('username');
 		$db['password'] = $this->ci->session->userdata('password');
 		$db['database'] = $this->ci->input->post('database');
-		$db['port'] 	= $this->ci->input->post('port');
+		$db['port'] = $this->ci->input->post('port');
 		$db['dbdriver'] = "mysql";
 		$db['dbprefix'] = 'default_';
-		$db['pconnect'] = FALSE;
-		$db['db_debug'] = TRUE;
-		$db['cache_on'] = FALSE;
+		$db['pconnect'] = false;
+		$db['db_debug'] = true;
+		$db['cache_on'] = false;
 		$db['cachedir'] = "";
 		$db['char_set'] = "utf8";
 		$db['dbcollat'] = "utf8_unicode_ci";
@@ -46,31 +47,33 @@ class Module_import {
 		$this->ci->load->helper('file');
 
 		// create the site specific addon folder
-		is_dir(ADDONPATH.'modules') OR mkdir(ADDONPATH.'modules', DIR_READ_MODE, TRUE);
-		is_dir(ADDONPATH.'themes') OR mkdir(ADDONPATH.'themes', DIR_READ_MODE, TRUE);
-		is_dir(ADDONPATH.'widgets') OR mkdir(ADDONPATH.'widgets', DIR_READ_MODE, TRUE);
-		is_dir(ADDONPATH.'field_types') OR mkdir(ADDONPATH.'field_types', DIR_READ_MODE, TRUE);
+		is_dir(ADDONPATH.'modules') OR mkdir(ADDONPATH.'modules', DIR_READ_MODE, true);
+		is_dir(ADDONPATH.'themes') OR mkdir(ADDONPATH.'themes', DIR_READ_MODE, true);
+		is_dir(ADDONPATH.'widgets') OR mkdir(ADDONPATH.'widgets', DIR_READ_MODE, true);
+		is_dir(ADDONPATH.'field_types') OR mkdir(ADDONPATH.'field_types', DIR_READ_MODE, true);
 
 		// create the site specific upload folder
-		is_dir(dirname(FCPATH).'/uploads/default') OR mkdir(dirname(FCPATH).'/uploads/default', DIR_WRITE_MODE, TRUE);
+		is_dir(dirname(FCPATH).'/uploads/default') OR mkdir(dirname(FCPATH).'/uploads/default', DIR_WRITE_MODE, true);
 
 		//insert empty html files
-		write_file(ADDONPATH.'modules/index.html','');
-		write_file(ADDONPATH.'themes/index.html','');
-		write_file(ADDONPATH.'widgets/index.html','');
-		write_file(PYROPATH.'uploads/index.html','');
+		write_file(ADDONPATH.'modules/index.html', '');
+		write_file(ADDONPATH.'themes/index.html', '');
+		write_file(ADDONPATH.'widgets/index.html', '');
+		write_file(ADDONPATH.'field_types/index.html', '');
+		write_file(PYROPATH.'uploads/index.html', '');
+		write_file(ADDONPATH.'uploads/default/index.html', '');
 	}
 
 
 	/**
-	 * Install
-	 *
 	 * Installs a module
 	 *
-	 * @param	string	$slug	The module slug
-	 * @return	bool
+	 * @param string $slug The module slug
+	 * @param bool   $is_core
+	 *
+	 * @return bool
 	 */
-	public function install($slug, $is_core = FALSE)
+	public function install($slug, $is_core = false)
 	{
 		$details_class = $this->_spawn_class($slug, $is_core);
 
@@ -80,18 +83,18 @@ class Module_import {
 		// Now lets set some details ourselves
 		$module['version'] = $details_class->version;
 		$module['is_core'] = $is_core;
-		$module['enabled'] = TRUE;
-		$module['installed'] = TRUE;
+		$module['enabled'] = true;
+		$module['installed'] = true;
 		$module['slug'] = $slug;
 
 		// set the site_ref and upload_path for third-party devs
-		$details_class->site_ref 	= 'default';
-		$details_class->upload_path	= 'uploads/default/';
+		$details_class->site_ref = 'default';
+		$details_class->upload_path = 'uploads/default/';
 
 		// Run the install method to get it into the database
-		if ( ! $details_class->install())
+		if (!$details_class->install())
 		{
-			return FALSE;
+			return false;
 		}
 
 		// Looks like it installed ok, add a record
@@ -105,10 +108,10 @@ class Module_import {
 			'slug' => $module['slug'],
 			'version' => $module['version'],
 			'description' => serialize($module['description']),
-			'skip_xss' => !empty($module['skip_xss']),
-			'is_frontend' => !empty($module['frontend']),
-			'is_backend' => !empty($module['backend']),
-			'menu' => !empty($module['menu']) ? $module['menu'] : FALSE,
+			'skip_xss' => ! empty($module['skip_xss']),
+			'is_frontend' => ! empty($module['frontend']),
+			'is_backend' => ! empty($module['backend']),
+			'menu' => ( ! empty($module['menu'])) ? $module['menu'] : false,
 			'enabled' => $module['enabled'],
 			'installed' => $module['installed'],
 			'is_core' => $module['is_core']
@@ -163,11 +166,13 @@ class Module_import {
 		$this->ci->db->query($session);
 
 		// Loop through directories that hold modules
-		$is_core = TRUE;
+		$is_core = true;
 		foreach (array(PYROPATH, ADDONPATH, SHARED_ADDONPATH) as $directory)
 		{
 			// some servers return false instead of an empty array
-			if ( ! $directory) continue;
+			if ( ! $directory) {
+				continue;
+			}
 
 			// Loop through modules
 			if ($modules = glob($directory.'modules/*', GLOB_ONLYDIR))
@@ -186,15 +191,16 @@ class Module_import {
 			}
 
 			// Going back around, 2nd time is addons
-			$is_core = FALSE;
+			$is_core = false;
 		}
 
 		// After modules are imported we need to modify the settings table
 		// This allows regular admins to upload addons on the first install but not on multi
-		$this->ci->db->where('slug', 'addons_upload')
+		$this->ci->db
+			->where('slug', 'addons_upload')
 			->update('settings', array('value' => '1'));
 
-		return TRUE;
+		return true;
 	}
 
 	/**
@@ -202,25 +208,26 @@ class Module_import {
 	 *
 	 * Checks to see if a details.php exists and returns a class
 	 *
-	 * @param	string	$module_slug	The folder name of the module
-	 * @access	private
-	 * @return	array
+	 * @param string $slug    The folder name of the module
+	 * @param bool   $is_core
+	 *
+	 * @return    array
 	 */
-	private function _spawn_class($slug, $is_core = FALSE)
+	private function _spawn_class($slug, $is_core = false)
 	{
 		$path = $is_core ? PYROPATH : ADDONPATH;
 
 		// Before we can install anything we need to know some details about the module
-		$details_file = $path . 'modules/' . $slug . '/details'.EXT;
+		$details_file = $path.'modules/'.$slug.'/details'.EXT;
 
 		// Check the details file exists
 		if ( ! is_file($details_file))
 		{
-			$details_file = SHARED_ADDONPATH . 'modules/' . $slug . '/details'.EXT;
+			$details_file = SHARED_ADDONPATH.'modules/'.$slug.'/details'.EXT;
 
 			if ( ! is_file($details_file))
 			{
-				return FALSE;
+				return false;
 			}
 		}
 
@@ -231,6 +238,6 @@ class Module_import {
 		$class = 'Module_'.ucfirst(strtolower($slug));
 
 		// Now we need to talk to it
-		return class_exists($class) ? new $class : FALSE;
+		return class_exists($class) ? new $class : false;
 	}
 }


### PR DESCRIPTION
- Fixed the `Module_import::__construct()` so that it writes the empty `index.html` to the places it didn't but should have.
- Fixed some PHPDoc comments.
- Applied PyroCMS coding standards to the entire `Module_import.php` file.
