### PR TITLE
[2.2/develop] File upload in WYSIWYG module does not save the description provided.

### DIFF
--- a/system/cms/modules/wysiwyg/controllers/upload.php
+++ b/system/cms/modules/wysiwyg/controllers/upload.php
@@ -51,7 +51,7 @@ class Upload extends WYSIWYG_Controller
 			if ($results['status'])
 			{
 				$data = $results['data'];
-				$this->file_m->update($data->id, array('description' => $input['description']));
+				$this->file_m->update($data['id'], array('description' => $input['description']));
 			}
 
 			// upload has a message to share... good or bad?


### PR DESCRIPTION
In the Upload controller of the WYSIWYG module the $data is an array, not an object.

This resulted in the uploaded file description to not get saved.
Fix #1802
