### PR TITLE
[2.2/develop] Blog module - Bad `comments_enabled` column data type.

### DIFF
--- a/system/cms/modules/blog/details.php
+++ b/system/cms/modules/blog/details.php
@@ -117,7 +117,7 @@ class Module_Blog extends Module {
 				'author_id' => array('type' => 'INT', 'constraint' => 11, 'default' => 0),
 				'created_on' => array('type' => 'INT', 'constraint' => 11),
 				'updated_on' => array('type' => 'INT', 'constraint' => 11, 'default' => 0),
-				'comments_enabled' => array('type' => 'INT', 'constraint' => 1, 'default' => 1),
+				'comments_enabled' => array('type' => 'ENUM', 'constraint' => array('no','1 day','1 week','2 weeks','1 month', '3 months', 'always'), 'default' => '3 months'),
 				'status' => array('type' => 'ENUM', 'constraint' => array('draft', 'live'), 'default' => 'draft'),
 				'type' => array('type' => 'SET', 'constraint' => array('html', 'markdown', 'wysiwyg-advanced', 'wysiwyg-simple')),
                 'preview_hash' => array('type' => 'CHAR', 'constraint' => 32,'default'=>''),


### PR DESCRIPTION
"The `comments_enabled` column is being installed as an INT and that made the blog module sad. Blog module will be happy after this pull request. Please! think of the unposted blog posts."
