### PR TITLE
Added user-select: none; to .btn class

### DIFF
--- a/system/cms/themes/pyrocms/css/workless/workless.css
+++ b/system/cms/themes/pyrocms/css/workless/workless.css
@@ -540,6 +540,10 @@ table .actions a {
   -webkit-transition: 250ms linear all;
   -moz-transition: 250ms linear all;
   transition: 250ms linear all;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .btn, .btn a, a.btn {


### PR DESCRIPTION
Adding user-select: none; eliminates the ability to highlight.

This also removes highlighting when double clicking.
