### PR TITLE
Plugin Attr Parsing fix

### DIFF
--- a/system/cms/libraries/Plugins.php
+++ b/system/cms/libraries/Plugins.php
@@ -45,9 +45,6 @@ abstract class Plugin
 				}
 			}
 			
-			// unset the parse_params since we no longer need it
-			unset($attributes['parse_params']);
-		
 			$this->attributes = $attributes;
 		}
 	}

--- a/system/cms/plugins/helper.php
+++ b/system/cms/plugins/helper.php
@@ -225,7 +225,14 @@ class Plugin_Helper extends Plugin
 
 		if (function_exists($name) and in_array($name, config_item('allowed_functions')))
 		{
-			return call_user_func_array($name, $this->attributes());
+			$attributes = $this->attributes();
+			
+			// unset automatically set attributes
+			if ( isset($attributes['parse_params']) ) {
+				unset($attributes['parse_params']);
+			}
+			
+			return call_user_func_array($name, $attributes);
 		}
 
 		return 'Function not found or is not allowed';


### PR DESCRIPTION
Moving the `parse_params` unset to the helper function instead. There
are some cases where you might still want to know if the user has
`parse_params` set and we only removed it to fix support for
`call_user_func_array()`
