### PR TITLE
[2.2/develop] Please don't delete installer when in development mode.

### DIFF
--- a/system/cms/controllers/admin.php
+++ b/system/cms/controllers/admin.php
@@ -32,7 +32,7 @@ class Admin extends Admin_Controller
 			$this->load->helper('file');
 
 			// if the contents of "installer" delete successfully then finish off the installer dir
-			if(delete_files('./installer', true) and count(scandir('./installer')) == 2 )
+			if(ENVIRONMENT != 'development' and delete_files('./installer', true) and count(scandir('./installer')) == 2 )
 			{
 				rmdir('./installer');
 			}


### PR DESCRIPTION
This is annoying, visit the admin area when trying out things while having forgotten to set read-only ot the installer dir and having to restore the whole dir.
