### PR TITLE
Settings::columns property should be declared static otherwise we get an...

### DIFF
--- a/system/cms/modules/settings/libraries/Settings.php
+++ b/system/cms/modules/settings/libraries/Settings.php
@@ -21,7 +21,7 @@ class Settings {
 	 *
 	 * @var	array
 	 */
-	private $columns = array('slug', 'title', 'description', 'type', 'default', 'value', 'options', 'is_required', 'is_gui', 'module', 'order');
+	private static $columns = array('slug', 'title', 'description', 'type', 'default', 'value', 'options', 'is_required', 'is_gui', 'module', 'order');
 
 	/**
 	 * The Settings Construct


### PR DESCRIPTION
... error when doing Settings::add()
