### PR TITLE
Widgets now can read inside $options the instance_title

### DIFF
--- a/system/cms/modules/widgets/libraries/Widgets.php
+++ b/system/cms/modules/widgets/libraries/Widgets.php
@@ -279,7 +279,7 @@ class Widgets {
 
 		foreach ($widgets as $widget)
 		{
-			$widget->options = $this->_unserialize_options($widget->options);
+			$widget->options = array_merge(array("instance_title" => $widget->instance_title), $this->_unserialize_options($widget->options));
 			$widget->body = $this->render($widget->slug, $widget->options);
 
 			if ($widget->body !== FALSE)


### PR DESCRIPTION
This change allow to access the instance_title inside the widget display view.
Currently you only can read the instance_title in a widget_wrapper.
