### PR TITLE
Fixes modules being installed after an error

### DIFF
--- a/system/cms/modules/addons/models/module_m.php
+++ b/system/cms/modules/addons/models/module_m.php
@@ -461,7 +461,7 @@ class Module_m extends MY_Model
 		$class->upload_path	= 'uploads/'.SITE_REF.'/';
 
 		// Run the install method to get it into the database
-		if( $class->install() )
+		if ($class->install())
 		{
 
 			// TURN ME ON BABY!


### PR DESCRIPTION
This stops modules being tagged as installed after false was returned from the modules install function.
