### PR TITLE
Fix MSIE conditionals regex in minify output

### DIFF
--- a/system/codeigniter/core/Output.php
+++ b/system/codeigniter/core/Output.php
@@ -654,7 +654,7 @@ class CI_Output {
 				$output = preg_replace('!\s{2,}!', ' ', $output);
 
 				// Remove comments (non-MSIE conditionals)
-				$output = preg_replace('{\s*<!--[^\[].*-->\s*}msU', '', $output);
+				$output = preg_replace('{\s*<!--[^\[<>].*(?<!!)-->\s*}msU', '', $output);
 
 				// Remove spaces around block-level elements.
 				$output = preg_replace('/\s*(<\/?(html|head|title|meta|script|link|style|body|h[1-6]|div|p|br)[^>]*>)\s*/is', '$1', $output);


### PR DESCRIPTION
Allows IE conditionals like the following to remain unmodified (from html5boilerplate):

``` html
<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
```

Without the change, the comment is not fully removed, remains unclosed, and the entire document is treated as commented!

Don't know how often pyro updates it's copy of CodeIgniter, but I have
also submitted this change to EllisLab/CodeIgniter#2120, with proper credit given there.
