### PR TITLE
Enable proper functionality of the current class for parents (has_current)

### DIFF
--- a/system/cms/helpers/MY_array_helper.php
+++ b/system/cms/helpers/MY_array_helper.php
@@ -154,3 +154,26 @@ if (!function_exists('assoc_array_prop'))
 	}
 
 }
+
+
+if(!function_exists('in_array_r'))
+{
+	/**
+	 * Recursively search an array
+	 * This method was copied and pasted from this URL (http://stackoverflow.com/questions/4128323/in-array-and-multidimensional-array)
+	 * Real credit goes to (http://stackoverflow.com/users/427328/elusive)
+	 *
+	 * @author Elusive / Brennon Loveless
+	 * @param string $needle the term being recursively searched for
+	 * @param array $haystack multidimensional array to search
+	 * @param boolean $strict use strict comparison or not
+	 */
+	function in_array_r($needle, $haystack, $strict = false) {
+		foreach ($haystack as $item) {
+			if (($strict ? $item === $needle : $item == $needle) || (is_array($item) && in_array_r($needle, $item, $strict))) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/system/cms/modules/navigation/plugin.php
+++ b/system/cms/modules/navigation/plugin.php
@@ -214,9 +214,9 @@ class Plugin_Navigation extends Plugin
 			// is the link we're currently working with found inside the children html?
 			if ( ! in_array($current_class, $wrapper['class']) and
 				isset($wrapper['children']) and
-					$current_link and
-						((is_array($wrapper['children']) and in_array($current_link, $wrapper['children'])) or
-							(is_string($wrapper['children']) and strpos($wrapper['children'], $current_link)))
+				$current_link and
+				((is_array($wrapper['children']) and in_array_r($current_link, $wrapper['children'])) or
+				(is_string($wrapper['children']) and strpos($wrapper['children'], $current_link)))
 			)
 			{
 				// that means that this link is a parent


### PR DESCRIPTION
When I was using the navigation the has_current class was never being put in the parent classes. I added an in_array_r function to search an array recursively looking for the current page within any level of navigation. I've only tested it with one level of navigation, but I'd assume that it will work with any level of navigation.
