### PR TITLE
nav section title in delete button. button red and angry.

### DIFF
--- a/system/cms/modules/navigation/css/navigation.css
+++ b/system/cms/modules/navigation/css/navigation.css
@@ -24,10 +24,12 @@ section.title li {
 }
 
 section.title li .button {
-	float:right;
+	float: right;
 	display: inline-block;
-	margin-right: 10px;
-/* margin-top: 6px; */
+	margin: 0 10px 0 0;
+	padding: 2px 6px;
+	font-size: 13px;
+	line-height: initial;
 }
 
 section.title li:first-child {
@@ -92,7 +94,7 @@ section.title .form-title {
 
 .sortable li {
 	margin:5px 0;
-	padding-left:20px;
+	padding-left:0px;
 }
 
 .sortable li div {
@@ -107,7 +109,7 @@ section.title .form-title {
 }
 
 .sortable li div:hover {
-	background-color:#bbb;
+	background-color:#dbdbdb;
 	-webkit-border-radius:4px;
 	-moz-border-radius:4px;
 	-o-border-radius:4px;
@@ -124,11 +126,11 @@ section.title .form-title {
 }
 
 .plus {
-	background:url(../img/more.png) no-repeat 0 7px;
+	background:url(../img/more.png) no-repeat 0 4px;
 }
 
 .minus {
-	background:url(../img/less.png) no-repeat 0 7px;
+	background:url(../img/less.png) no-repeat 0 4px;
 }
 
 /* Right pane */

--- a/system/cms/modules/navigation/views/admin/index.php
+++ b/system/cms/modules/navigation/views/admin/index.php
@@ -1,6 +1,6 @@
 <?php if ( ! empty($groups)): ?>
 	<?php foreach ($groups as $group): ?>
-	
+
 		<section rel="<?php echo $group->id ?>" class="group-<?php echo $group->id ?> box">
 			<div class="one_full">
 				<section class="title files-title">
@@ -8,18 +8,18 @@
 						<li>
 							<h4 class="tooltip" title="<?php echo lang('nav:abbrev_label').': '.$group->abbrev ?>"><?php echo $group->title;?></h4>
 						</li>
-						
-						<li><?php echo anchor('admin/navigation/groups/delete/'.$group->id, lang('global:delete'), array('class' => 'tooltip-e confirm button',  'title' => lang('nav:group_delete_confirm'))) ?></li>
+
+						<li><?php echo anchor('admin/navigation/groups/delete/'.$group->id, lang('global:delete').' '.$group->title, array('class' => 'tooltip-e confirm btn button red',  'title' => lang('nav:group_delete_confirm'))) ?></li>
 						<li>
 							<!-- <h4 class="form-title group-title-<?php echo $group->id ?>"></h4> -->
 							<?php echo anchor('admin/navigation/create/'.$group->id, lang('nav:link_create_title'), 'rel="'.$group->id.'" class="add ajax button"') ?>
 						</li>
 					</ul>
-				
+
 				</section>
-				
+
 				<?php if ( ! empty($navigation[$group->id])): ?>
-				
+
 				<section class="item collapsed">
 						<div class="content">
 							<div class="one_half">
@@ -29,20 +29,20 @@
 									</ul>
 								</div>
 							</div>
-							
+
 							<div class="one_half last">
 								<div id="link-details" class="group-<?php echo $group->id ?>">
-									
+
 									<p>
 										<?php echo lang('navs.tree_explanation') ?>
 									</p>
-									
+
 								</div>
 							</div>
-						</div>	
+						</div>
 					</section>
 				</div>
-										
+
 				<?php else:?>
 
 				<section class="item collapsed">
@@ -50,30 +50,30 @@
 						<div class="one_half">
 							<div id="link-list" class="empty">
 								<ul class="sortable">
-							
+
 									<p><?php echo lang('nav:group_no_links');?></p>
-							
+
 								</ul>
 							</div>
 						</div>
-						
-						<div class="one_half last">	
+
+						<div class="one_half last">
 							<div id="link-details" class="group-<?php echo $group->id ?>">
-								
+
 								<p>
 									<?php echo lang('navs.tree_explanation') ?>
 								</p>
-								
+
 							</div>
 						</div>
 					</div>
 				</section>
-				<?php endif ?>	
-					
+				<?php endif ?>
+
 		</section>
-		
+
 	<?php endforeach ?>
-		
+
 <?php else: ?>
 	<div class="blank-slate">
 		<p><?php echo lang('nav:no_groups');?></p>


### PR DESCRIPTION
I have had a few different clients delete their navigation in the last month or so.

I believe this is because they think they are deleting a link when they are actually deleting the navigation group.

![Screen Shot 2013-01-14 at 4 14 50 PM](https://f.cloud.github.com/assets/1425304/65963/0444ce04-5e93-11e2-92c0-3bfd048fa244.png)

The default is they are both named delete. They are both the same color and size and in the same proximity. I think this could be solved by clarifying which delete is the one you _DON'T_ want to click.

![Screen Shot 2013-01-14 at 4 40 43 PM](https://f.cloud.github.com/assets/1425304/65983/44da2612-5e93-11e2-8997-54054d508545.png)

So what I did was make the button the standard warning/red and make it contain the title of the group it is in.

A subtle alternate is having the link delete say "Delete Link" and the header delete to say "Delete _Group Title_"

Here is a screenshot:

![Screen Shot 2013-01-14 at 4 45 02 PM](https://f.cloud.github.com/assets/1425304/66009/c7c2cd54-5e93-11e2-86e9-73c7b197159e.png)
