### PR TITLE
Profile id is not always the same as user_id

### DIFF
--- a/system/cms/libraries/MY_Form_validation.php
+++ b/system/cms/libraries/MY_Form_validation.php
@@ -423,13 +423,13 @@ class MY_Form_validation extends CI_Form_validation
 		$mode 		= $items[1];
 		$stream_id	= $items[2];
 
-		if ($mode == 'edit' and isset($items[3]) and is_numeric($items[3]))
-		{
-			$row_id = $items[3];
-		}
-		elseif ($mode == 'edit' and $this->CI->input->post('row_edit_id'))
+		if ($mode == 'edit' and $this->CI->input->post('row_edit_id'))
 		{
 			$row_id = $this->CI->input->post('row_edit_id');
+		}
+		elseif ($mode == 'edit' and isset($items[3]) and is_numeric($items[3]))
+		{
+			$row_id = $items[3];
 		}
 		else
 		{
@@ -467,7 +467,7 @@ class MY_Form_validation extends CI_Form_validation
 			$existing = $this->CI->db
 				->select($column)
 				->limit(1)
-				->where('user_id', $row_id)
+				->where('id', $row_id)
 				->get($stream->stream_prefix.$stream->stream_slug)
 				->row();
 

--- a/system/cms/modules/users/views/admin/form.php
+++ b/system/cms/modules/users/views/admin/form.php
@@ -6,6 +6,7 @@
 	<?php else: ?>
 		<h4><?php echo sprintf(lang('user:edit_title'), $member->username) ?></h4>
 		<?php echo form_open_multipart(uri_string(), 'class="crud"') ?>
+		<?php echo form_hidden('row_edit_id', isset($member->row_edit_id) ? $member->row_edit_id : $member->profile_id); ?>
 	<?php endif ?>
 </section>
 


### PR DESCRIPTION
This fixes a bug with unique fields not validating correctly when the profile id and the user id go out of sync.
