### PR TITLE
Fixed colspan in redirects admin module

### DIFF
--- a/system/cms/modules/redirects/views/admin/index.php
+++ b/system/cms/modules/redirects/views/admin/index.php
@@ -20,7 +20,7 @@
 		    </thead>
 			<tfoot>
 				<tr>
-					<td colspan="4">
+					<td colspan="5">
 						<div class="inner"><?php $this->load->view('admin/partials/pagination') ?></div>
 					</td>
 				</tr>


### PR DESCRIPTION
Table footer stopped one column short. 
