### PR TITLE
add param data to param pre_save method call

### DIFF
--- a/system/cms/modules/streams_core/models/fields_m.php
+++ b/system/cms/modules/streams_core/models/fields_m.php
@@ -453,7 +453,7 @@ class Fields_m extends CI_Model {
 			{
 				if (method_exists($type, 'param_'.$param.'_pre_save'))
 				{
-					$update_data['custom'][$param] = $type->{'param_'.$param.'_pre_save'}( $insert_data );
+					$update_data['custom'][$param] = $type->{'param_'.$param.'_pre_save'}( $update_data );
 				}
 			}
 			


### PR DESCRIPTION
At the moment, it is currently impossible to get the parameter data in the custom pre_save method when creating a field from the API. So, we need to pass that data into the custom pre_save function.
