### PR TITLE
Fix loss of 'current' class for blog link if reading blog post

### DIFF
--- a/system/cms/modules/navigation/plugin.php
+++ b/system/cms/modules/navigation/plugin.php
@@ -210,6 +210,13 @@ class Plugin_Navigation extends Plugin
 				$current_link       = $link['url'];
 				$wrapper['class'][] = $current_class;
 			}
+			
+			// if we are reading blog post, mark blog link as 'current'
+			if($link['module_name'] === 'blog' AND strpos(current_url(), $link['url']) !== FALSE)
+			{
+				$current_link = $link['url'];
+				$wrapper['class'][] = $current_class;	
+			}
 
 			// is the link we're currently working with found inside the children html?
 			if ( ! in_array($current_class, $wrapper['class']) and


### PR DESCRIPTION
Blog link is marked as 'current' while on the top, not browsing any
of blog articles (http://mysite.com/blog/).
If user browse article (http://mysite.com/blog/1/my-very-first-blog-post)
main blong link loses 'current' class. This piece of code fixes this problem.
