### PR TITLE
workaround: top-bar hides when ckeditor is maximized, "solves" GH-2261

### DIFF
--- a/system/cms/themes/pyrocms/js/scripts.js
+++ b/system/cms/themes/pyrocms/js/scripts.js
@@ -58,7 +58,7 @@ jQuery(function($) {
 						$('.hide-on-ckeditor-maximize').addClass('hidden');
 						$('.cke_button__maximize').addClass('ckeditor-pyro-logo');
 					}
-					else if(data == 2) //snap back
+					else if(e.data == 2) //snap back
 					{
 						$('.hide-on-ckeditor-maximize').removeClass('hidden');
 						$('.cke_button__maximize').removeClass('ckeditor-pyro-logo');


### PR DESCRIPTION
the maximize event gets called twice, but you can check what's going on in the e.data var. I guess it's more of a workaround than a real solution... but I couldn't find out why the event get's calles twice and I looked really hard :(

client is happy, I'm tired ^^
