### PR TITLE
Fix: return empty when a page is not available in the db

### DIFF
--- a/system/cms/modules/pages/models/page_m.php
+++ b/system/cms/modules/pages/models/page_m.php
@@ -252,6 +252,11 @@ class Page_m extends MY_Model
 			->get($this->_table)
 			->row();
 
+        if ( ! $page)
+        {
+            return;
+        }
+        
 		$page->stream_entry_found = false;
 
 		if ($page and $page->type_id and $get_data)


### PR DESCRIPTION
The get method of the page model used to return empty on a missing
page.

Currently it returns an object with a variable called
stream_entry_found, which is added to the page object by the get method
itself.

This causes an issue with the edit method in the pages admin
controller. Quite possibly it causes issues elsewhere too.
