### PR TITLE
fix streams_core/models/fields_m - offset calculation when using page numbers

### DIFF
--- a/system/cms/modules/streams_core/models/fields_m.php
+++ b/system/cms/modules/streams_core/models/fields_m.php
@@ -77,7 +77,7 @@ class Fields_m extends CI_Model {
 		
 		if ($namespace) $this->db->where('field_namespace', $namespace);
 	
-		if ($offset) $this->db->offset($offset);
+		if ($offset && $limit) $this->db->offset(($offset - 1) * $limit);
 		
 		if ($limit) $this->db->limit($limit);
 


### PR DESCRIPTION
since this fixes stuff in the fields model, other modules might be affected. Since use_page_numbers is hard coded in the pagination helper, this should actually be good for everything involved.

Only case, I can think of, where it will fail is if someone uses an offset without a limit. But on the other hand, that would'nt be a pagination so.... meh

But I've only checked the fields index in the streams admin.
