### PR TITLE
Working fix: Enabling pages plugin for new 2.2 installs

### DIFF
--- a/system/cms/modules/pages/plugin.php
+++ b/system/cms/modules/pages/plugin.php
@@ -94,27 +94,27 @@ class Plugin_Pages extends Plugin
 			->get('pages')
 			->row();
         
-        $page->body = '';
+		$page->body = '';
         
-        // Legacy support for chunks
-        if ($this->db->table_exists('page_chunks'))
-        {
-    		// Grab all the chunks that make up the body
-    		$page->chunks = $this->db->get_where('page_chunks', array('page_id' => $page->id))->result();
+		// Legacy support for chunks
+		if ($this->db->table_exists('page_chunks'))
+		{
+			// Grab all the chunks that make up the body
+			$page->chunks = $this->db->get_where('page_chunks', array('page_id' => $page->id))->result();
     		
-    		if ($page->chunks)
-    		{
-    			foreach ($page->chunks as $chunk)
-    			{
-    				$page->body .= '<div class="page-chunk '.$chunk->slug.'">' .
-    					(($chunk->type == 'markdown') ? $chunk->parsed : $chunk->body) .
-    					'</div>' . PHP_EOL;
-    			}
-    		}
+			if ($page->chunks)
+			{
+    				foreach ($page->chunks as $chunk)
+				{
+					$page->body .= '<div class="page-chunk '.$chunk->slug.'">' .
+					(($chunk->type == 'markdown') ? $chunk->parsed : $chunk->body) .
+					'</div>' . PHP_EOL;
+				}
+			}
     
-    		// we'll unset the chunks array as Lex is grouchy about mixed data at the moment
-    		unset($page->chunks);
-        }
+			// we'll unset the chunks array as Lex is grouchy about mixed data at the moment
+			unset($page->chunks);
+		}
         
 		return $this->content() ? array($page) : $page->body;
 	}
@@ -212,7 +212,7 @@ class Plugin_Pages extends Plugin
 			->get('pages')
 			->result_array();
 
-        // Legacy support for chunks
+		// Legacy support for chunks
 		if ($pages && $this->db->table_exists('page_chunks'))
 		{
 			foreach ($pages as &$page)


### PR DESCRIPTION
(Edit) As Phil commented, legacy support for chunks is not fixed by this simple commit. This request is therefore just a temporary fix for new 2.2 installs, to enable those to use the pages plugin without running into database errors while a permanent fix including legacy support for chunks is worked on.

---

I figure adding a simple check for the existence of the chunks database table fixes current issues experienced with fresh installs of 2.2, while maintaining legacy support for chunks for older installs.

Fixes: https://github.com/pyrocms/pyrocms/issues/2211
