### PR TITLE
Return success as false if remote container is not found

### DIFF
--- a/system/cms/modules/files/libraries/Files.php
+++ b/system/cms/modules/files/libraries/Files.php
@@ -255,7 +255,7 @@ class Files
 				return self::result(true, lang('files:container_exists'), $name);
 			}
 		}
-		return self::result(true, lang('files:container_not_exists'), $name);
+		return self::result(false, lang('files:container_not_exists'), $name);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
In the Files library, the check_container function always returns true even if the container is not found. The error message is correct, but the success status is wrong when the container doesn't exist.
