### PR TITLE
Fixes an issue with upper/lowercase chars in slugs

### DIFF
--- a/system/cms/libraries/MY_Form_validation.php
+++ b/system/cms/libraries/MY_Form_validation.php
@@ -474,7 +474,7 @@ class MY_Form_validation extends CI_Form_validation
 			// Is this the same value? If so, we are
 			// all in the clear. They did not change the value
 			// so we don't need to worry.
-			if ($existing->$column == $string)
+			if (strtolower($existing->$column) == strtolower($string))
 			{
 				return true;
 			}


### PR DESCRIPTION
Because of inconsistencies in MySQL and PHP with case-sensitivity strings that aren't the same may be matched in one and not the other causing validation to fail.
