### PR TITLE
Fixes issue pyrocms/pyrocms-professional#113

### DIFF
--- a/system/cms/modules/streams_core/field_types/keywords/field.keywords.php
+++ b/system/cms/modules/streams_core/field_types/keywords/field.keywords.php
@@ -45,11 +45,16 @@ class Field_keywords
 
 	public function event($field)
 	{
-		$this->CI->template->append_css('jquery/jquery.tagsinput.css');
-		$this->CI->template->append_js('jquery/jquery.tagsinput.js');
+		$admin_theme = BASE_URL.'system/cms/themes/pyrocms/';
+		$this->CI->type->add_misc(
+			'<link rel="stylesheet" href="'.$admin_theme.'css/jquery/jquery.tagsinput.css">'
+		);
+		$this->CI->type->add_misc(
+			'<script src="'.$admin_theme.'js/jquery/jquery.tagsinput.js"></script>'
+		);
 		$this->CI->type->add_js('keywords', 'keywords.js');
 		$this->CI->type->add_misc(
-			'<script type="text/javascript">
+			'<script>
 				jQuery(document).ready(function(){pyro.field_tags_input("'.$field->field_slug.'");});
 			</script>'
 		);


### PR DESCRIPTION
Fixes issue pyrocms/pyrocms-professional#113 with loading css and js if keywords field form is accessed from public.

This was done from 2.2/develop branch because it had the latest changes to the keywords field type, but it applies and should be merged to 2.1 community and professional, as well as 2.2 professional and 2.3/develop.
