### PR TITLE
Update "Records per page" translation

### DIFF
--- a/system/cms/modules/settings/language/english/settings_lang.php
+++ b/system/cms/modules/settings/language/english/settings_lang.php
@@ -62,7 +62,7 @@ $lang['settings:activation_email']				= 'Activation Email';
 $lang['settings:activation_email_desc']			= 'Send out an e-mail when a user signs up with an activation link. Disable this to let only admins activate accounts.';
 
 $lang['settings:records_per_page']				= 'Records Per Page';
-$lang['settings:records_per_page_desc']			= 'How many records should we show per page in the admin section?';
+$lang['settings:records_per_page_desc']			= 'How many records should we show per page? (both for frontend and for admin section) e.g.: blog posts, users etc.';
 
 $lang['settings:rss_feed_items']				= 'Feed item count';
 $lang['settings:rss_feed_items_desc']			= 'How many items should we show in RSS/blog feeds?';

--- a/system/cms/modules/settings/language/french/settings_lang.php
+++ b/system/cms/modules/settings/language/french/settings_lang.php
@@ -61,8 +61,8 @@ $lang['settings:default_theme_desc'] 			= 'Sélectionnez le thème que vous souh
 $lang['settings:activation_email'] 				= 'E-mail d\'activation';
 $lang['settings:activation_email_desc'] 		= 'Envoyer un e-mail quand un utilisateur s\'inscrit avec un lien d\'activation. Désactiver cette option pour laisser les admins activer les comptes.';
 
-$lang['settings:records_per_page'] 				= 'Enregistrements par page';
-$lang['settings:records_per_page_desc'] 		= 'Combien d\'enregistrements devons nous montrer par page dans la section admin?';
+$lang['settings:records_per_page'] 				= 'Entrées par page';
+$lang['settings:records_per_page_desc'] 		= 'Combien d\'entrées devons nous montrer par page ? (valable dans la partie publique du site et dans l\'interface d\'administration) Ex. : articles du blog, utilisateurs etc.';
 
 $lang['settings:rss_feed_items'] 				= 'Nombre de flux RSS';
 $lang['settings:rss_feed_items_desc'] 			= 'Nombre d\'entrée à afficher dans les flux blog et RSS ?';


### PR DESCRIPTION
"Records per page" instructions should not only say on the admin
section.
Issue #2430
