### PR TITLE
Fix "Array to string conversion" error in users/activate

### DIFF
--- a/system/cms/modules/users/views/activate.php
+++ b/system/cms/modules/users/views/activate.php
@@ -23,7 +23,7 @@
 	</li>
 
 	<li>
-		<?php echo form_submit('btnSubmit', lang('user:activate_btn'), array('class' => 'pyro_button')) ?>
+		<?php echo form_submit('btnSubmit', lang('user:activate_btn')) ?>
 	</li>
 </ul>
 <?php echo form_close() ?>


### PR DESCRIPTION
Fixed "Array to string conversion" error on the user activate page. 

Removed the `pyro_button` class completely as it's not used.
