### PR TITLE
Add another check before session_start() and AUTO_LANGUAGE

### DIFF
--- a/system/cms/core/MY_Controller.php
+++ b/system/cms/core/MY_Controller.php
@@ -283,7 +283,7 @@ class MY_Controller extends MX_Controller
         // If we've been redirected from HTTP to HTTPS on admin, ?session= will be set to maintain language
         if ($_SERVER['SERVER_PORT'] == 443 and ! empty($_GET['session'])) {
             session_start($_GET['session']);
-        } else {
+        } else if ( ! isset($_SESSION)) {
             session_start();
         }
 
@@ -360,8 +360,11 @@ class MY_Controller extends MX_Controller
         $CI_config->set_item('language', $config['supported_languages'][$lang]['folder']);
 
         // Sets a constant to use throughout ALL of CI.
-        define('AUTO_LANGUAGE', $lang);
-
+        if ( ! defined('AUTO_LANGUAGE'))
+        {
+            define('AUTO_LANGUAGE', $lang);    
+        }
+        
         log_message('debug', 'Defined const AUTO_LANGUAGE: '.AUTO_LANGUAGE);
     }
 }


### PR DESCRIPTION
Added checks before session_start() and AUTO_LANGUAGE to avoid errors.

These errors I found while working on the Eloquent refactor for Navigation. For example when trying to create a link.

ErrorException [ Notice ]: A session had already been started - ignoring session_start()
FCPATH/system/cms/core/MY_Controller.php [ 287 ]
282 
283         // If we've been redirected from HTTP to HTTPS on admin, ?session= will be set to maintain language
284         if ($_SERVER['SERVER_PORT'] == 443 and ! empty($_GET['session'])) {
285             session_start($_GET['session']);
286         } else {
287             session_start();
288         }
289 
290         // Lang set in URL via ?lang=something
291         if ( ! empty($_GET['lang'])) {
292             // Turn en-gb into en
    1.  {PHP internal call} » MY_Exceptions::error_handler(arguments)
    2.  FCPATH/system/cms/core/MY_Controller.php [ 287 ] » session_start()
    3.  FCPATH/system/cms/core/MY_Controller.php [ 44 ] » MY_Controller->pick_language()
    4.  FCPATH/system/cms/core/Admin_Controller.php [ 26 ] » MY_Controller->__construct()
    5.  FCPATH/system/cms/modules/navigation/controllers/admin.php [ 91 ] » Admin_Controller->__construct()
    6.  FCPATH/system/cms/libraries/MY_Form_validation.php [ 256 ] » Admin->__construct()
    7.  FCPATH/system/codeigniter/libraries/Form_validation.php [ 466 ] » MY_Form_validation->_execute(arguments)
    8.  FCPATH/system/cms/modules/navigation/controllers/admin.php [ 203 ] » CI_Form_validation->run()
    9.  {PHP internal call} » Admin->create()
    10. FCPATH/system/codeigniter/core/CodeIgniter.php [ 356 ] » call_user_func_array(arguments)
    11. FCPATH/index.php [ 287 ] » require_once(arguments)
Environment
ErrorException [ Notice ]: Constant AUTO_LANGUAGE already defined
FCPATH/system/cms/core/MY_Controller.php [ 363 ]
358 
359         // Set the language config. Selects the folder name from its key of 'en'
360         $CI_config->set_item('language', $config['supported_languages'][$lang]['folder']);
361 
362         // Sets a constant to use throughout ALL of CI.
363         define('AUTO_LANGUAGE', $lang);
364 
365         log_message('debug', 'Defined const AUTO_LANGUAGE: '.AUTO_LANGUAGE);
366     }
367 }
368 
    1.  {PHP internal call} » MY_Exceptions::error_handler(arguments)
    2.  FCPATH/system/cms/core/MY_Controller.php [ 363 ] » define(arguments)
    3.  FCPATH/system/cms/core/MY_Controller.php [ 44 ] » MY_Controller->pick_language()
    4.  FCPATH/system/cms/core/Admin_Controller.php [ 26 ] » MY_Controller->__construct()
    5.  FCPATH/system/cms/modules/navigation/controllers/admin.php [ 91 ] » Admin_Controller->__construct()
    6.  FCPATH/system/cms/libraries/MY_Form_validation.php [ 256 ] » Admin->__construct()
    7.  FCPATH/system/codeigniter/libraries/Form_validation.php [ 466 ] » MY_Form_validation->_execute(arguments)
    8.  FCPATH/system/cms/modules/navigation/controllers/admin.php [ 203 ] » CI_Form_validation->run()
    9.  {PHP internal call} » Admin->create()
    10. FCPATH/system/codeigniter/core/CodeIgniter.php [ 356 ] » call_user_func_array(arguments)
    11. FCPATH/index.php [ 287 ] » require_once(arguments)
Environment
ErrorException [ Warning ]: Cannot modify header information - headers already sent by (output started at /Users/ob/Sites/pyrocms/2.3/system/cms/core/MY_Exceptions.php:188)
FCPATH/system/codeigniter/libraries/Session/drivers/Session_cookie.php [ 722 ]
717      \* @param   bool    HTTP protocol only flag
718      \* @return  void
719      _/
720     protected function _setcookie($name, $value = '', $expire = 0, $path = '', $domain = '', $secure = FALSE, $httponly = FALSE)
721     {
722         setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
723     }
724 
725     // ------------------------------------------------------------------------
726 
727     /_*
    1.  {PHP internal call} » MY_Exceptions::error_handler(arguments)
    2.  FCPATH/system/codeigniter/libraries/Session/drivers/Session_cookie.php [ 722 ] » setcookie(arguments)
    3.  FCPATH/system/codeigniter/libraries/Session/drivers/Session_cookie.php [ 701 ] » CI_Session_cookie->_setcookie(arguments)
    4.  FCPATH/system/codeigniter/libraries/Session/drivers/Session_cookie.php [ 289 ] » CI_Session_cookie->_set_cookie()
    5.  FCPATH/system/codeigniter/libraries/Session/Session.php [ 312 ] » CI_Session_cookie->sess_save()
    6.  FCPATH/system/codeigniter/libraries/Session/Session.php [ 380 ] » CI_Session->set_userdata(arguments)
    7.  FCPATH/system/cms/modules/navigation/controllers/admin.php [ 216 ] » CI_Session->set_flashdata(arguments)
    8.  {PHP internal call} » Admin->create()
    9.  FCPATH/system/codeigniter/core/CodeIgniter.php [ 356 ] » call_user_func_array(arguments)
    10. FCPATH/index.php [ 287 ] » require_once(arguments)
