### PR TITLE
Removing required rule on password field in installer

### DIFF
--- a/installer/controllers/installer.php
+++ b/installer/controllers/installer.php
@@ -168,7 +168,7 @@ class Installer extends CI_Controller
             array(
                 'field' => 'password',
 				'label'	=> 'lang:password',
-				'rules'	=> 'trim'.(in_array($driver, array('mysql', 'pgsql')) ? '|required' : '')
+				'rules'	=> 'trim'
             ),
             array(
                 'field' => 'port',


### PR DESCRIPTION
on Localhost, by default password is not required for default user ( 'root' ).
