### PR TITLE
allow wysiwyg in widgets. update html widget with wysiwyg-advanced by default

### DIFF
--- a/system/cms/modules/widgets/controllers/admin.php
+++ b/system/cms/modules/widgets/controllers/admin.php
@@ -2,7 +2,7 @@
 
 /**
  * Admin controller for the widgets module.
- * 
+ *
  * @author 		PyroCMS Dev Team
  * @package 	PyroCMS\Core\Modules\Widgets\Controllers
  *
@@ -18,7 +18,7 @@ class Admin extends Admin_Controller {
 
 	/**
 	 * Constructor method
-	 * 
+	 *
 	 * @return void
 	 */
 	public function __construct()
@@ -38,12 +38,13 @@ class Admin extends Admin_Controller {
 
 		$this->template
 			->append_js('module::widgets.js')
-			->append_css('module::widgets.css');
+			->append_css('module::widgets.css')
+			->append_metadata($this->load->view('fragments/wysiwyg', array(), true));
 	}
 
 	/**
 	 * Index method, lists all active widgets
-	 * 
+	 *
 	 * @return void
 	 */
 	public function index()
@@ -182,14 +183,14 @@ class Admin extends Admin_Controller {
 			}
 			else
 			{
-				// Fire an Event. A widget has been enabled or disabled. 
+				// Fire an Event. A widget has been enabled or disabled.
 				switch ($action)
 				{
-					case 'enable':		
+					case 'enable':
 						Events::trigger('widget_enabled', $ids);
 						break;
-					
-					case 'disable':		
+
+					case 'disable':
 						Events::trigger('widget_disabled', $ids);
 						break;
 				}

--- a/system/cms/widgets/html/views/form.php
+++ b/system/cms/widgets/html/views/form.php
@@ -1,6 +1,11 @@
+<script>
+(function($){
+  pyro.init_ckeditor();
+})(jQuery);
+</script>
 <ul>
 	<li class="even">
 		<label>HTML</label>
-		<?php echo form_textarea(array('name'=>'html', 'value' => $options['html'])); ?>
+		<?php echo form_textarea(array('name'=>'html', 'value' => $options['html'], 'class' => 'wysiwyg-advanced')); ?>
 	</li>
 </ul>


### PR DESCRIPTION
So pretty much every client has asked for a WYSIWYG in the HTML widget. Normally I would copy the packaged html widget, rename it wysiwyg, and then add the wysiwyg partial to the widgets admin controller.

Here is the after:
![new-wysiwyg](https://f.cloud.github.com/assets/1425304/217619/26c02ca2-84f0-11e2-9760-37cabed59f4a.jpg)
