### PR TITLE
Fix for the Event "admin_menu"

### DIFF
--- a/system/cms/core/Admin_Controller.php
+++ b/system/cms/core/Admin_Controller.php
@@ -121,13 +121,14 @@ class Admin_Controller extends MY_Controller {
 
 			// Trigger an event so modules can mess with the
 			// menu items array via the events structure. 
-			$event_output = Events::trigger('admin_menu', $menu_items);
+			$event_output = Events::trigger('admin_menu', $menu_items, 'array');
 
 			// If we get an array, we assume they have altered the menu items
-			// and are returning them to us to use.
-			if (is_array($event_output))
+			// anyone listening would have changed it one after the other so
+			// we only want that last.
+			if (count($event_output))
 			{
-				$menu_items = $event_output;
+				$menu_items = $event_output[count($event_output) - 1 ];
 			}
 
 			// Order the menu items. We go by our menu_order array.


### PR DESCRIPTION
Fix for the Core Event "admin_menu"
The default return of type string was incorrect (and actually threw an error).
Once switched to "return array" the array would have contained an extra top level
because everyone would have gotten a copy of $menu which was returned and appended to the trigger return array therefore we need to dive in and grab the last modifed menu
