### PR TITLE
MY_Controller now loads the database settings from 2.2

### DIFF
--- a/system/cms/core/MY_Controller.php
+++ b/system/cms/core/MY_Controller.php
@@ -273,7 +273,7 @@ class MY_Controller extends MX_Controller
     /**
     * Build the DSN from the config options.
     * TODO: decide if this is ok or build the DSN somewhere else
-    * in the code base.
+    * in the code base. Not 100% sure where this shoulo be done.
     */
     private function buildDsn($config)
     {


### PR DESCRIPTION
Eh, was playing around with upgrading to 2.3 and see how far I could get into a "working" 2.3 development instance. This seemed to fix several issues loading and using the database and while I'm sure I'm doing something wrong, this should be a good starting point.
