### PR TITLE
Only load field type if it hasn't already been loaded

### DIFF
--- a/system/cms/modules/streams_core/libraries/Type.php
+++ b/system/cms/modules/streams_core/libraries/Type.php
@@ -153,20 +153,24 @@ class Type
 
 		foreach ($types_files as $type)
 		{
-			// Is this a directory w/ a field type?
-			if (is_dir($addon_path.$type) and is_file($addon_path.$type.'/field.'.$type.'.php'))
+			// Check if we've already loaded this field type
+			if ( ! property_exists($this->types, $type))
 			{
-				$this->types->$type = $this->_load_type($addon_path, 
-									$addon_path.$type.'/field.'.$type.'.php',
-									$type,
-									$mode);
-			}			
-			elseif (is_file($addon_path.'field.'.$type.'.php'))
-			{
-				$this->types->$type = $this->_load_type($addon_path, 
-									$addon_path.'field.'.$type.'.php',
-									$type,
-									$mode);												
+				// Is this a directory w/ a field type?
+				if (is_dir($addon_path.$type) and is_file($addon_path.$type.'/field.'.$type.'.php'))
+				{
+					$this->types->$type = $this->_load_type($addon_path, 
+										$addon_path.$type.'/field.'.$type.'.php',
+										$type,
+										$mode);
+				}			
+				elseif (is_file($addon_path.'field.'.$type.'.php'))
+				{
+					$this->types->$type = $this->_load_type($addon_path, 
+										$addon_path.'field.'.$type.'.php',
+										$type,
+										$mode);												
+				}
 			}
 		}
 	}
@@ -182,23 +186,31 @@ class Type
 	 */	
 	public function load_single_type($type)
 	{
-		foreach ($this->addon_paths as $mode => $path)
+		// Check if we've already loaded this field type
+		if ( ! property_exists($this->types, $type))
 		{
-			// Is this a directory w/ a field type?
-			if (is_dir($path.$type) and is_file($path.$type.'/field.'.$type.'.php'))
+			foreach ($this->addon_paths as $mode => $path)
 			{
-				return $this->_load_type($path, 
-									$path.$type.'/field.'.$type.'.php',
-									$type,
-									$mode);		
+				// Is this a directory w/ a field type?
+				if (is_dir($path.$type) and is_file($path.$type.'/field.'.$type.'.php'))
+				{
+					return $this->_load_type($path, 
+										$path.$type.'/field.'.$type.'.php',
+										$type,
+										$mode);		
+				}
+				elseif (is_file($path.'field.'.$type.'.php'))
+				{
+					return $this->_load_type($path, 
+										$path.'field.'.$type.'.php',
+										$type,
+										$mode);
+				}					
 			}
-			elseif (is_file($path.'field.'.$type.'.php'))
-			{
-				return $this->_load_type($path, 
-									$path.'field.'.$type.'.php',
-									$type,
-									$mode);
-			}					
+		}
+		else
+		{
+			return $this->types->$type;
 		}
 		
 		return null;


### PR DESCRIPTION
This fixes an issue where an "can not redeclare class" error would be thrown if a field type exists in multiple locations.

This fix also comes with some performance improvements because if an instance of a field type already exists, it'll return that instead of reinstantiating it.

I'm not sure if this change will cause any issues elsewhere, but after doing some testing, it seems to work fine.
