### PR TITLE
Default parameter for the Streams update_entry() method

### DIFF
--- a/system/cms/libraries/Streams/drivers/Streams_entries.php
+++ b/system/cms/libraries/Streams/drivers/Streams_entries.php
@@ -242,7 +242,7 @@ class Streams_entries extends CI_Driver {
 	 * @param 	bool - update only the passed values?
 	 * @return	object
 	 */
-	public function update_entry($entry_id, $entry_data, $stream, $namespace, $skips = array(), $extra = array(), $include_only_passed = false)
+	public function update_entry($entry_id, $entry_data, $stream, $namespace, $skips = array(), $extra = array(), $include_only_passed = true)
 	{
 		$str_obj = $this->stream_obj($stream, $namespace);
 		

--- a/system/cms/modules/streams_core/models/row_m.php
+++ b/system/cms/modules/streams_core/models/row_m.php
@@ -1283,7 +1283,7 @@ class Row_m extends MY_Model {
 	 * @param 	bool    Should we only update those passed?
 	 * @return	bool
 	 */
-	public function update_entry($fields, $stream, $row_id, $form_data, $skips = array(), $extra = array(), $include_only_passed = false)
+	public function update_entry($fields, $stream, $row_id, $form_data, $skips = array(), $extra = array(), $include_only_passed = true)
 	{
 		$this->load->helper('text');
 


### PR DESCRIPTION
As discussed in [issue 2557](https://github.com/pyrocms/pyrocms/issues/2557) the default for the `$include_only_passed` parameter has been set to `true`.
