### PR TITLE
Fixes #2585. Installer showed warning for undefined variable.

### DIFF
--- a/installer/controllers/installer.php
+++ b/installer/controllers/installer.php
@@ -267,6 +267,7 @@ class Installer extends CI_Controller
 		$data->http_server = new stdClass();
 
 		// Check the PHP version
+		$data->php_min_version	= '5.2';
 		$data->php_acceptable	= $this->installer_lib->php_acceptable();
 		$data->php_version		= PHP_VERSION;
 


### PR DESCRIPTION
When the server did not meet the minimum requirements an undefined variable would throw a warning.
