### PR TITLE
bugfix in get_stream_fields ignoring skips array

### DIFF
--- a/system/cms/modules/streams_core/models/streams_m.php
+++ b/system/cms/modules/streams_core/models/streams_m.php
@@ -685,7 +685,7 @@ class Streams_m extends MY_Model {
 	public function get_stream_fields($stream_id, $limit = false, $offset = false, $skips = array())
 	{	
 		// Check and see if there is a cache
-		if (isset($this->stream_fields_cache[$stream_id]) and ! $limit and ! $offset)
+		if (isset($this->stream_fields_cache[$stream_id]) and ! $limit and ! $offset and empty($skips) )
 		{
 			return $this->stream_fields_cache[$stream_id];
 		}


### PR DESCRIPTION
If I try to get the fields of a streams with a skips array, get_stream_fields ignore my skips array because cache ignore skips array.
