### PR TITLE
keep cache consistent with real database state

### DIFF
--- a/system/cms/modules/streams_core/models/fields_m.php
+++ b/system/cms/modules/streams_core/models/fields_m.php
@@ -586,6 +586,18 @@ class Fields_m extends CI_Model {
 		{
 			return false;
 		}
+		
+		// Remove from cache
+		if(isset($this->fields_cache['by_id'][$field_id]))
+		{
+			unset($this->fields_cache['by_id'][$field_id]);
+		}
+		$field_namespace = $field->field_namespace;
+		$field_slug = $field->field_slug;
+		if(isset($this->fields_cache['by_slug'][$field_namespace.':'.$field_slug]))
+		{
+			unset($this->fields_cache['by_slug'][$field_namespace.':'.$field_slug]);
+		}
 	
 		// Find assignments, and delete rows from table
 		$assignments = $this->get_assignments($field_id);


### PR DESCRIPTION
Added this because the field cache was causing my module install problems. 

Reproduce with following steps:
- module version 0.1 creates stream and adds fields x, y, z
- module version 0.2 removes z field
- module version 0.3 adds z field back again

Upgrading step by step would be fine (i.e. during development). But once deployed and the installer drops through each version in succession, the cache steps in and causes problems. Namely that adding the z field back again in 0.3 fails because the z field is already in the cache from 0.1.
