### PR TITLE
Replaced login slide down animation with shorter fade in and bounce

### DIFF
--- a/system/cms/themes/pyrocms/css/workless/responsive.css
+++ b/system/cms/themes/pyrocms/css/workless/responsive.css
@@ -916,10 +916,10 @@ button#login-submit:hover {
 ------------------------------------------------------------------ */
 
 #login-logo {
-  -webkit-animation-delay: 1s;
-     -moz-animation-delay: 1s;
-       -o-animation-delay: 1s;
-          animation-delay: 1s;
+  -webkit-animation-delay: 0;
+     -moz-animation-delay: 0;
+       -o-animation-delay: 0;
+          animation-delay: 0;
   -webkit-animation-duration: 1s;
      -moz-animation-duration: 1s;
        -o-animation-duration: 1s;
@@ -931,14 +931,14 @@ button#login-submit:hover {
 }
 
 #login-un {
-  -webkit-animation-delay: 2s;
-     -moz-animation-delay: 2s;
-       -o-animation-delay: 2s;
-          animation-delay: 2s;
-  -webkit-animation-duration: .25s;
-     -moz-animation-duration: .25s;
-       -o-animation-duration: .25s;
-          animation-duration: .25s;
+  -webkit-animation-delay: 0;
+     -moz-animation-delay: 0;
+       -o-animation-delay: 0;
+          animation-delay: 0;
+  -webkit-animation-duration: .5s;
+     -moz-animation-duration: .5s;
+       -o-animation-duration: .5s;
+          animation-duration: .5s;
   -webkit-animation-iteration-count: 1;
      -moz-animation-iteration-count: 1;
        -o-animation-iteration-count: 1;
@@ -946,14 +946,14 @@ button#login-submit:hover {
 }
 
 #login-pw {
-  -webkit-animation-delay: 2.25s;
-     -moz-animation-delay: 2.25s;
-       -o-animation-delay: 2.25s;
-          animation-delay: 2.25s;
-  -webkit-animation-duration: .25s;
-     -moz-animation-duration: .25s;
-       -o-animation-duration: .25s;
-          animation-duration: .25s;
+  -webkit-animation-delay: 0;
+     -moz-animation-delay: 0;
+       -o-animation-delay: 0;
+          animation-delay: 0;
+  -webkit-animation-duration: .5s;
+     -moz-animation-duration: .5s;
+       -o-animation-duration: .5s;
+          animation-duration: .5s;
   -webkit-animation-iteration-count: 1;
      -moz-animation-iteration-count: 1;
        -o-animation-iteration-count: 1;
@@ -961,14 +961,14 @@ button#login-submit:hover {
 }
 
 #login-save {
-  -webkit-animation-delay: 2.5s;
-     -moz-animation-delay: 2.5s;
-       -o-animation-delay: 2.5s;
-          animation-delay: 2.5s;
-  -webkit-animation-duration: .25s;
-     -moz-animation-duration: .25s;
-       -o-animation-duration: .25s;
-          animation-duration: .25s;
+  -webkit-animation-delay: 0;
+     -moz-animation-delay: 0;
+       -o-animation-delay: 0;
+          animation-delay: 0;
+  -webkit-animation-duration: .5s;
+     -moz-animation-duration: .5s;
+       -o-animation-duration: .5s;
+          animation-duration: .5s;
   -webkit-animation-iteration-count: 1;
      -moz-animation-iteration-count: 1;
        -o-animation-iteration-count: 1;
@@ -976,14 +976,14 @@ button#login-submit:hover {
 }
 
 #login-action {
-  -webkit-animation-delay: 2.75s;
-     -moz-animation-delay: 2.75s;
-       -o-animation-delay: 2.75s;
-          animation-delay: 2.75s;
-  -webkit-animation-duration: .25s;
-     -moz-animation-duration: .25s;
-       -o-animation-duration: .25s;
-          animation-duration: .25s;
+  -webkit-animation-delay: 0;
+     -moz-animation-delay: 0;
+       -o-animation-delay: 0;
+          animation-delay: 0;
+  -webkit-animation-duration: .5s;
+     -moz-animation-duration: .5s;
+       -o-animation-duration: .5s;
+          animation-duration: .5s;
   -webkit-animation-iteration-count: 1;
      -moz-animation-iteration-count: 1;
        -o-animation-iteration-count: 1;
@@ -991,10 +991,10 @@ button#login-submit:hover {
 }
 
 #login-credits {
-  -webkit-animation-delay: 3s;
-     -moz-animation-delay: 3s;
-       -o-animation-delay: 3s;
-          animation-delay: 3s;
+  -webkit-animation-delay: 0;
+     -moz-animation-delay: 0;
+       -o-animation-delay: 0;
+          animation-delay: 0;
   -webkit-animation-duration: 1s;
      -moz-animation-duration: 1s;
        -o-animation-duration: 1s;

--- a/system/cms/themes/pyrocms/views/admin/login.php
+++ b/system/cms/themes/pyrocms/views/admin/login.php
@@ -26,19 +26,19 @@
 	<section id="content">
 		<div id="content-body">
 
-			<div class="animated fadeInDown" id="login-logo"></div>
+			<div class="animated bounceIn" id="login-logo"></div>
 			<?php $this->load->view('admin/partials/notices') ?>
 				<?php echo form_open('admin/login'); ?>
 				<div class="form_inputs">
 					<ul>
 						<li>
-							<div class="input animated fadeInDown" id="login-un"><input type="text" name="email" placeholder="<?php echo lang('global:email'); ?>"/></div>
+							<div class="input animated fadeIn" id="login-un"><input type="text" name="email" placeholder="<?php echo lang('global:email'); ?>"/></div>
 						</li>
 
 						<li>
-							<div class="input animated fadeInDown" id="login-pw"><input type="password" name="password" placeholder="<?php echo lang('global:password'); ?>"/></div>
+							<div class="input animated fadeIn" id="login-pw"><input type="password" name="password" placeholder="<?php echo lang('global:password'); ?>"/></div>
 						</li>
-						<li class="animated fadeInDown" id="login-save">
+						<li class="animated fadeIn" id="login-save">
 							<label for="remember-check" id="login-remember">
 								<input type="checkbox" name="remember" id="remember-check" checked />
 								<?php echo lang('user:remember'); ?>
@@ -59,7 +59,7 @@
 	</section>
 </div>
 <footer id="login-footer">
-	<div class="wrapper animated fadeInUp" id="login-credits">
+	<div class="wrapper animated fadeIn" id="login-credits">
 		Copyright &copy; 2009 - <?php echo date('Y'); ?> PyroCMS LLC 
 		<br><span id="version"><?php echo CMS_VERSION.' '.CMS_EDITION; ?></span>
 	</div>


### PR DESCRIPTION
The admin login page had a total of 4 seconds of animation and delays, with about 3.5s before the page was useable. It was waiting 1 full second, and then running all animations serially. I've set it to 1) have no delay before animation begins, 2) animate the logo with a 1s bounceIn, 3) run animations in parallel, 4) .5s fadeIn for the inputs.

In total, this removes about 3 seconds of waiting before logging in.
