### PR TITLE
Delete the hash in case status is live in blog edit page

### DIFF
--- a/system/cms/modules/blog/controllers/admin.php
+++ b/system/cms/modules/blog/controllers/admin.php
@@ -334,7 +334,9 @@ class Admin extends Admin_Controller
 		{
 			$hash = $this->_preview_hash();
 		}
-
+                //it is going to be published we don't need the hash
+                ($this->input->post('status') == 'live') AND $hash = '';
+                
 		if ($this->form_validation->run())
 		{
 			$author_id = empty($post->display_name) ? $this->current_user->id : $post->author_id;


### PR DESCRIPTION
When a blog post is published using the publish method in the
controller, we clear the hash, here should do that too here.
