### PR TITLE
Resolved conflict in datetime's default input_type

### DIFF
--- a/system/cms/modules/streams_core/field_types/datetime/field.datetime.php
+++ b/system/cms/modules/streams_core/field_types/datetime/field.datetime.php
@@ -93,7 +93,7 @@ class Field_datetime
 
 		if ( ! isset($field->field_data['input_type']))
 		{
-			$field->field_data['input_type'] = 'dropdown';
+			$field->field_data['input_type'] = 'datepicker';
 		}
 
 		if ($field->field_data['input_type'] == 'dropdown' and $required)


### PR DESCRIPTION
In the absence of an input_type, the validate() method in the datetime field type was defaulting to "dropdown" but the form_output() method was displaying a datepicker. Resolved in favor of datepicker.
