### PR TITLE
Removes the requirement to add cellspacing="0"

### DIFF
--- a/system/cms/themes/pyrocms/css/workless/workless.css
+++ b/system/cms/themes/pyrocms/css/workless/workless.css
@@ -788,7 +788,9 @@ table {
   margin-bottom: 18px;
   font-size: 13px;
   border: 1px solid #ddd;
-  border-collapse: separate;
+	border-collapse: separate;
+	border-spacing: 0px;
+	*border-collapse: expression('separate', cellSpacing = '0px');
   border-radius: 3px;
 }
 


### PR DESCRIPTION
Cross-browser solution to remove the need for cellspacing="0" cellpadding.. on tables.
as @adamfairholm pointed out in 9d11f5b (with commented out css I might add) =)
