### PR TITLE
Fixes a bug for `parse_param` plugin attribute being passed to tag generators (img)

### DIFF
--- a/system/cms/libraries/Plugins.php
+++ b/system/cms/libraries/Plugins.php
@@ -28,15 +28,22 @@ abstract class Plugin
 	 */
 	public function set_data($content, $attributes)
 	{
-		$content AND $this->content = $content;
+		$content and $this->content = $content;
 
 		if ($attributes)
 		{
-			// Let's get parse_params first since it
-			// dictates how we handle all tags
-			if ( ! isset($attributes['parse_params'])) $attributes['parse_params'] = true;
+			// Let's get parse-params first since it dictates how we handle all tags
+			// Default: true
+			$parse_params = true;
+			$set = false;
+			foreach (array('parse_params','parse-params') as $attr) {
+				if (isset($attributes[$attr]) and ! $set) {
+					$parse_params = str_to_bool($attributes[$attr]);
+					$set = true;
+				}
+			}
 			
-			if (str_to_bool($attributes['parse_params']))
+			if ($parse_params)
 			{
 				// For each attribute, let's see if we need to parse it.
 				foreach ($attributes as $key => $attr)


### PR DESCRIPTION
Previously we set `parse_params="true"` behind the scenes which caused a bug for code that took all parameters such as the `<img>` tag generator. This will remove the auto setting attribute and simply keep the default behavior of parsing parameters by default. If a user wants to change it, they can add `parse_params="false"`.

This also has deprecation for the underscores in favor of `parse-params` instead.
