### PR TITLE
After delete, show message in files manager on error, not just success

### DIFF
--- a/system/cms/modules/files/js/functions.js
+++ b/system/cms/modules/files/js/functions.js
@@ -872,9 +872,8 @@ jQuery(function($){
 					if ($folders_center.find('li').length === 0 && pyro.files.current_level === 0) {
 						$('.no_data').fadeIn('fast');
 					}
-
-					$(window).trigger('show-message', results);
 				}
+				$(window).trigger('show-message', results);
 			});
 		});
 	 };


### PR DESCRIPTION
On attempting to delete a non-empty folder, I noticed that the message sent from the server ('You must delete the contents of "folder" first') was not being displayed. This fixes that.
