### PR TITLE
Fix Query String for Sorting with ORDER BY 

### DIFF
--- a/system/cms/modules/streams_core/models/streams_m.php
+++ b/system/cms/modules/streams_core/models/streams_m.php
@@ -499,7 +499,7 @@ class Streams_m extends CI_Model
 		// Check if there is one now
 		if ($this->input->get('order-'.$stream->stream_slug))
 		{
-			$this->db->order_by($this->input->get('order-'.$stream->stream_slug), $this->input->get('order-'.$stream->stream_slug) ? $this->input->get('order-'.$stream->stream_slug) : 'ASC');
+			$this->db->order_by($this->input->get('order-'.$stream->stream_slug), $this->input->get('order-'.$stream->stream_slug) ? $this->input->get('sort-'.$this->input->get('order-'.$stream->stream_slug)) : 'ASC');
 		}
 		elseif ($stream->sorting == 'title' and ($stream->title_column != '' and $this->db->field_exists($stream->title_column, $stream->stream_prefix.$stream->stream_slug)))
 		{


### PR DESCRIPTION
Will allow sorting in either ASC or DESC through query string.

``` html
eg: ?order-<stream-slug>=<field-slug>[&sort-<field_slug>=asc|desc]
```

if not specified, It will sort in ASC order.
