### PR TITLE
Page module serves cached search results

### DIFF
--- a/system/cms/modules/pages/controllers/pages.php
+++ b/system/cms/modules/pages/controllers/pages.php
@@ -100,7 +100,14 @@ class Pages extends Public_Controller
 		}
 
 		// GET THE PAGE ALREADY. In the event of this being the home page $url_segments will be null
-		$page = $this->pyrocache->model('page_m', 'get_by_uri', array($url_segments, true));
+		if($_SERVER['REQUEST_METHOD'] != 'POST' && $_GET['q'] == '') 
+		{
+			$page = $this->pyrocache->model('page_m', 'get_by_uri', array($url_segments, true));
+		} 
+		else 
+		{
+			$page = $this->page_m->get_by_uri($url_segments, true);
+		}
 
 		// Setting this so others may use it.
 		$this->template->set('page', $page);


### PR DESCRIPTION
I tested this in two separate installations of PyroCMS 2.2/develop in the past few days. If you are [not in the `PYRO_DEVELOPMENT`environment](https://github.com/pyrocms/pyrocms/blob/2.3/develop/system/cms/modules/pages/controllers/pages.php#L78), the Pages module will serve cached page contents, even if you submit a search query via `$_GET`. That means, the first person who searches something gets fresh results, and everybody after that will get the first person's search results regardless of the search term …

Please note that I merely included the quick fix I deployed for a client, I'm not sure if it should be done that way …
