### PR TITLE
When saving keywords, delete existing applied keywords first

### DIFF
--- a/system/cms/modules/streams_core/field_types/keywords/field.keywords.php
+++ b/system/cms/modules/streams_core/field_types/keywords/field.keywords.php
@@ -52,8 +52,18 @@ class Field_keywords
 	}
 
 
-	public function pre_save($input)
+	public function pre_save($input, $field=null, $stream=null, $row_id=null)
 	{
+		// Remove any existing applied keywords
+		if (!empty($row_id) and !empty($stream))
+		{
+			$this->CI->load->model(array('keywords/keyword_m', 'streams_core/row_m'));
+
+			$row = $this->CI->row_m->get_row($row_id, $stream, false);
+			$keyword_hash = $row->keywords;
+			$this->CI->keyword_m->delete_applied($keyword_hash);
+		}
+
 		return Keywords::process($input);
 	}
 


### PR DESCRIPTION
#### Issue

Currently, when saving a stream that has a **Keywords** field, the old hash for the stream row remains in the **keywords_applied** table. So the **keywords_applied** table can get filled up with rows containing meaningless hashes which no longer reference a row.
#### Proposed Solution

In the **pre_save** method of **field.keywords.php**, check if the row being saved already exists, and if so, delete any existing applied keywords.
#### Remaining Issues

If the saving process fails at some point after **pre_save** for the Keywords field, but before the new set of keywords is applied, the existing applied keywords will be lost.
