### PR TITLE
Fixes an SQL error. Added argument to disable field_assignment_construct()

### DIFF
--- a/system/cms/libraries/Streams/drivers/Streams_utilities.php
+++ b/system/cms/libraries/Streams/drivers/Streams_utilities.php
@@ -120,10 +120,12 @@ class Streams_utilities extends CI_Driver
 		// Order The Columns
 		// ----------------------------
 
-		ci()->db->query("ALTER TABLE {ci()->db->dbprefix($prefix.$table_slug)} MODIFY COLUMN created DATETIME AFTER id");
-		ci()->db->query("ALTER TABLE {ci()->db->dbprefix($prefix.$table_slug)} MODIFY COLUMN updated DATETIME AFTER created");
-		ci()->db->query("ALTER TABLE {ci()->db->dbprefix($prefix.$table_slug)} MODIFY COLUMN created_by INT AFTER updated");
-		ci()->db->query("ALTER TABLE {ci()->db->dbprefix($prefix.$table_slug)} MODIFY COLUMN ordering_count INT AFTER created_by");
+		$base_query = 'ALTER TABLE '.ci()->db->dbprefix($prefix.$table_slug).' MODIFY COLUMN ';
+
+		ci()->db->query($base_query.'created DATETIME AFTER id');
+		ci()->db->query($base_query.'updated DATETIME AFTER created');
+		ci()->db->query($base_query.'created_by INT AFTER updated');
+		ci()->db->query($base_query.'ordering_count INT AFTER created_by');
 
 		// ----------------------------
 		// Add to stream table
@@ -154,7 +156,7 @@ class Streams_utilities extends CI_Driver
 	 * @param	string - namespace
 	 * @return	bool
 	 */
-	public function convert_column_to_field($stream_slug, $namespace, $field_name, $field_slug, $field_type, $extra = array(), $assign_data = array())
+	public function convert_column_to_field($stream_slug, $namespace, $field_name, $field_slug, $field_type, $extra = array(), $assign_data = array(), $field_assignment_construct = true)
 	{
 		// Get the stream
 		if ( ! $stream = $this->stream_obj($stream_slug, $namespace)) {
@@ -220,7 +222,7 @@ class Streams_utilities extends CI_Driver
 		// Add actual assignment
 		// The 4th parameter is to stop the column from being
 		// created, since we already did that.
-		return ci()->streams_m->add_field_to_stream($field_id, $stream->id, $data, false);
+		return ci()->streams_m->add_field_to_stream($field_id, $stream->id, $data, false, $field_assignment_construct);
 	}
 
 }

--- a/system/cms/modules/streams_core/models/streams_m.php
+++ b/system/cms/modules/streams_core/models/streams_m.php
@@ -664,7 +664,7 @@ class Streams_m extends CI_Model
 	 * @param	[bool - should we create the column?]
 	 * @return	mixed - false or assignment ID
 	 */
-	public function add_field_to_stream($field_id, $stream_id, $data, $create_column = true)
+	public function add_field_to_stream($field_id, $stream_id, $data, $create_column = true, $field_assignment_construct = true)
 	{
 		// TODO This whole method needs to be recoded to use Schema...
 
@@ -693,7 +693,7 @@ class Streams_m extends CI_Model
 		if ( ! $field_type) return false;
 
 		// Do we have a pre-add function?
-		if (method_exists($field_type, 'field_assignment_construct')) {
+		if (method_exists($field_type, 'field_assignment_construct') and $field_assignment_construct) {
 			$field_type->field_assignment_construct($field, $stream);
 		}
 


### PR DESCRIPTION
I know that this libraries eventually will get PSRed but this is a quick fix so we can keep converting modules to streams.

We need the option to disable the field_assignment_construct() to prevent it from creating columns that already exist when we use convert_column_to_field() in migrations. This is needed for my upcoming Variables to Streams migration to work.
