### PR TITLE
Adding event for comments

### DIFF
--- a/system/cms/modules/comments/controllers/comments.php
+++ b/system/cms/modules/comments/controllers/comments.php
@@ -133,6 +133,9 @@ class Comments extends Public_Controller
 					} else {
 						// Do we need to approve the comment?
 						$this->session->set_flashdata('success', lang('comments:add_approve'));
+						
+						// Trigger an event
+						Events::trigger('comment_added', $comment);
 					}
 
 					// If markdown is allowed we will parse the body for the email


### PR DESCRIPTION
Triggering event when comment is added. This is so third-party modules such as spam detection can hook in.
