### PR TITLE
#2516 Create namespaces with asset plugin: Adding add_path() function.

### DIFF
--- a/system/cms/plugins/asset.php
+++ b/system/cms/plugins/asset.php
@@ -576,4 +576,22 @@ class Plugin_Asset extends Plugin
 		return Asset::render_js_inline();
 	}
 
+    /**
+     * Asset Add Namespace
+     *
+     * Add namespace.
+     *
+     * Usage:
+     *
+     * {{ asset:add_path namespace="" path="" }}
+     *
+     */
+    function add_path()
+    {
+        $namespace = $this->attribute('namespace', '');
+        $path = $this->attribute('path', '');
+
+        Asset::add_path($namespace, $path);
+    }
+
 }


### PR DESCRIPTION
At PyroCMS pro version, I use in the majority of my websites, assets like jquery or bootstrap. So, I place them in assets/jquery and assets/bootstrap instead of placing them in the theme.

I think that could be useful to include a call to asset:add_path in the asset plugin to create namespaces.
