### PR TITLE
boolean() properly creates the hidden column as a TINYINT of lenght 1.

### DIFF
--- a/system/cms/modules/files/details.php
+++ b/system/cms/modules/files/details.php
@@ -114,7 +114,7 @@ class Module_Files extends AbstractModule
 			$table->string('remote_container', 100)->nullable();
 			$table->integer('date_added');
 			$table->integer('sort')->default(0);
-			$table->integer('hidden')->default(0);
+			$table->boolean('hidden')->default(0);
 		});
 
 		// Install the settings


### PR DESCRIPTION
Relates to #2836. Sorry about this folks. As suggested, boolean() is the way to do it. I installed a fresh copy of 2.3/develop with this change and it works properly.
