### PR TITLE
Update field.choice.php

### DIFF
--- a/system/cms/modules/streams_core/field_types/choice/field.choice.php
+++ b/system/cms/modules/streams_core/field_types/choice/field.choice.php
@@ -72,7 +72,7 @@ class Field_choice
 			$default_value = (isset($params['custom']['default_value'])) ? $params['custom']['default_value'] : null;
 
 			// If this is a new input, we need to use the default value or go null
-			$value = ( ! $entry_id) ? $default_value : $params['value']; 
+			$value = !is_null($entry_id) ? $default_value : $params['value']; 
 
 			return form_dropdown($params['form_slug'], $choices, $value, 'id="'.$params['form_slug'].'"');
 		}	


### PR DESCRIPTION
Based on my tests on differents sites the form_dropdownd would not manage correctly the value after a form error.
The problem was a misinterpretation of the !$entry_id that always was valued as false.
The !is_null instead works perfectly.
Please test it and if good merge to the project!
