### PR TITLE
Update sitemap module sitemap.php

### DIFF
--- a/system/cms/modules/sitemap/controllers/sitemap.php
+++ b/system/cms/modules/sitemap/controllers/sitemap.php
@@ -40,6 +40,17 @@ class Sitemap extends Public_Controller
 			) {
 				continue;
 			}
+			
+			if( $module['slug'] == "blog" )
+			{
+				$this->load->model('blog/blog_m');
+				$posts = $this->blog_m->get_many_by(array('status', 'live'));
+				
+				if( count($posts) == 0 )
+				{
+					continue;
+				}
+			}
 
 			$basic = new SitemapEntry;
 			$basic->setLocation(site_url($module['slug'].'/sitemap/xml'));


### PR DESCRIPTION
This fix is included to solve this bug: https://github.com/pyrocms/pyrocms/issues/2838
Now the function check if there are posts with status "Live", if the count is 0 then the loop doesn't print the blog link to the sitemap
