### PR TITLE
Add ob_end_clean to a few places that need it in order for the admin to ...

### DIFF
--- a/system/cms/modules/files/controllers/admin.php
+++ b/system/cms/modules/files/controllers/admin.php
@@ -106,6 +106,7 @@ class Admin extends Admin_Controller {
 
 		$result['status'] AND Events::trigger('file_folder_created', $result['data']);
 
+		ob_end_flush();
 		echo json_encode($result);
 	}
 
@@ -132,6 +133,7 @@ class Admin extends Admin_Controller {
 	{
 		$parent = $this->input->post('parent');
 
+		ob_end_clean();
 		echo json_encode(Files::folder_contents($parent));
 	}
 
@@ -196,6 +198,7 @@ class Admin extends Admin_Controller {
 			
 			$result['status'] AND Events::trigger('file_folder_updated', $id);
 
+			ob_end_flush();
 			echo json_encode($result);
 		}
 	}
@@ -249,6 +252,7 @@ class Admin extends Admin_Controller {
 			$result['status'] AND Events::trigger('file_uploaded', $result['data']);
 		}
 
+		ob_end_flush();
 		echo json_encode($result);		
 	}
 

--- a/system/cms/modules/files/controllers/files_front.php
+++ b/system/cms/modules/files/controllers/files_front.php
@@ -237,7 +237,7 @@ class Files_front extends Public_Controller
 
 		header('Content-type: ' . $file->mimetype);
 		header('Last-Modified: ' . gmdate('D, d M Y H:i:s', filemtime($thumb_filename)) . ' GMT');
-		ob_clean();
+		ob_end_clean();
 		readfile($thumb_filename);
 	}
 
@@ -270,6 +270,7 @@ class Files_front extends Public_Controller
 				exit();
 			}
 
+			ob_end_clean();
 			header('Content-type: ' . $file->mimetype);
 			header('Last-Modified: ' . gmdate('D, d M Y H:i:s', filemtime($thumb_filename)) . ' GMT');
 			readfile($thumb_filename);

--- a/system/cms/modules/keywords/controllers/admin.php
+++ b/system/cms/modules/keywords/controllers/admin.php
@@ -166,6 +166,7 @@ class Admin extends Admin_Controller
 
 	public function autocomplete()
 	{
+		ob_end_clean();
 		echo json_encode(
 			$this->keyword_m->select('name value')
 				->like('name', $this->input->get('term'))

--- a/system/cms/modules/navigation/controllers/admin.php
+++ b/system/cms/modules/navigation/controllers/admin.php
@@ -223,6 +223,7 @@ class Admin extends Admin_Controller {
 			$input['restricted_to'] = isset($input['restricted_to']) ? implode(',', $input['restricted_to']) : '';
 
 			// Got post?
+			ob_end_clean();
 			if ($this->navigation_m->insert_link($input) > 0)
 			{
 				$this->pyrocache->delete_all('navigation_m');

--- a/system/cms/modules/pages/controllers/admin.php
+++ b/system/cms/modules/pages/controllers/admin.php
@@ -100,6 +100,7 @@ class Admin extends Admin_Controller {
     			$html .= '</a></li>';
     		}
     		
+    		ob_end_clean();
     		echo $html .= '</ul>';
             return;
         }

--- a/system/cms/modules/streams_core/controllers/ajax.php
+++ b/system/cms/modules/streams_core/controllers/ajax.php
@@ -103,6 +103,7 @@ class Ajax extends MY_Controller {
 			
 			$data['input_slug'] = $field;
 		
+			ob_get_level() and ob_end_clean();
 			echo $this->load->view('extra_field', $data, true);
 			
 			$data['count']++;


### PR DESCRIPTION
...work correctly when gzip is enabled. I noticed in a few places there seems to be something that is put in the output buffer when certain functions are being called. I've gone through the CMS and found, what I believe, are all the places that this is happening and put some ob_end_clean calls in there in order to make the gzip compression work again.
