### PR TITLE
Update index.php in install folder

### DIFF
--- a/installer/index.php
+++ b/installer/index.php
@@ -199,6 +199,24 @@
 
 /*
  * --------------------------------------------------------------------
+ * CHECK PHP VERSION
+ * --------------------------------------------------------------------
+ *
+ * We need 5.3.7 or higher
+ *
+ */
+ if (!defined('PHP_VERSION_ID')) {
+    $version = explode('.', PHP_VERSION);
+    define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
+}
+
+if( PHP_VERSION_ID < 50307 ){
+	echo "You need php 5.3.7 or higher to install PyroCMS. Please update your version and reload this page.<br>Your current version is: ".PHP_VERSION;
+	exit();
+}
+
+/*
+ * --------------------------------------------------------------------
  * LOAD THE COMPOSER AUTOLOADER
  * --------------------------------------------------------------------
  *


### PR DESCRIPTION
I have added a control version for php.
Users should know which php version is required to install PyroCMS before run composer install in order to avoid the last step problem.
If users try to install Pyro with a lower version the installation process stops to the 4th step without any message.
With this fix users already know what they need
