### PR TITLE
Fix: Plugins methods translations were not being shown in CP

### DIFF
--- a/system/cms/modules/addons/views/admin/plugins/_docs.php
+++ b/system/cms/modules/addons/views/admin/plugins/_docs.php
@@ -7,7 +7,7 @@
 					<?php foreach ($plugin['self_doc'] as $method => $doc): ?>
 						<div class="method">
 							<h1><?php echo $plugin['slug'].':'.$method ?></h1>
-							<p><?php echo htmlentities(isset($doc['description'][CURRENT_LANGUAGE]) ? $doc['description'][CURRENT_LANGUAGE] : isset($doc['description']['en']) ? $doc['description']['en'] : '') ?></p>
+							<p><?php echo htmlentities(isset($doc['description'][CURRENT_LANGUAGE]) ? $doc['description'][CURRENT_LANGUAGE] : (isset($doc['description']['en']) ? $doc['description']['en'] : ''), ENT_COMPAT, 'UTF-8') ?></p>
 <pre>
 <code>
 <?php if (isset($doc['single']) and $doc['single']): ?>


### PR DESCRIPTION
Plugins methods descriptions were shown only in English in admin/addons/plugins.
Also, when showing accented characters, `htmlentities()` was messing with them. So the quote style and charset parameters were added.
