### PR TITLE
Fixes "Trying to get property of non-object" when trying to lookup a mod...

### DIFF
--- a/system/cms/modules/addons/models/module_m.php
+++ b/system/cms/modules/addons/models/module_m.php
@@ -63,13 +63,16 @@ class Module_m extends MY_Model
 			->get($this->_table)
 			->row();
 		
-		// store these
-		$this->_module_exists[$slug] = count($row) > 0;
-		$this->_module_enabled[$slug] = $row->enabled;
-		$this->_module_installed[$slug] = $row->installed;
+
 
 		if ($row)
 		{
+
+            // store these
+            $this->_module_exists[$slug] = count($row) > 0;
+            $this->_module_enabled[$slug] = $row->enabled;
+            $this->_module_installed[$slug] = $row->installed;
+
 			// Let's get REAL
 			if ( ! $module = $this->_spawn_class($slug, $row->is_core))
 			{
@@ -106,7 +109,12 @@ class Module_m extends MY_Model
 				'path' => $location,
 				'updated_on' => $row->updated_on
 			);
-		}
+		} else {
+            // store these, all are false, since we couldn't find a module entry
+            $this->_module_exists[$slug] = false;
+            $this->_module_enabled[$slug] = false;
+            $this->_module_installed[$slug] = false;
+        }
 
 		return $null_array;
 	}


### PR DESCRIPTION
...ule somewhere in the code when the module isn't installed/found in the database.

An example of this is the "forums" module, which tries to look up the "messaging" module to check if it's installed or not.
