### PR TITLE
Update comments.php

### DIFF
--- a/system/cms/modules/comments/controllers/comments.php
+++ b/system/cms/modules/comments/controllers/comments.php
@@ -86,11 +86,10 @@ class Comments extends Public_Controller
 			$comment['user_id'] = $this->current_user->id;
 			$comment['user_name'] = $this->current_user->display_name;
 			$comment['user_email'] = $this->current_user->email;
-			$comment['user_website'] = $this->current_user->website;
 
 			if (isset($this->current_user->website))
 			{
-				$comment['website'] = $this->current_user->website;
+				$comment['user_website'] = $this->current_user->website;
 			}
 		}
 		else


### PR DESCRIPTION
The line "$comment['user_website'] = $this->current_user->website;" was removed in this commit: https://github.com/pyrocms/pyrocms/commit/73788f4a7d66519756a03f30e09f1468f553be37 

$comment['website'] = $this->current_user->website; 

The model insert user_website, not website. I see using of 'website' only in the display view of 2.3 on line 11 https://github.com/pyrocms/pyrocms/blob/2.3/develop/system/cms/modules/comments/views/display.php#L11.
