### PR TITLE
Query string stream sorting correction

### DIFF
--- a/system/cms/modules/streams_core/models/streams_m.php
+++ b/system/cms/modules/streams_core/models/streams_m.php
@@ -593,7 +593,7 @@ class Streams_m extends MY_Model {
 		// Check if there is one now
 		if ($this->input->get('order-'.$stream->stream_slug))
 		{
-			$this->db->order_by($this->input->get('order-'.$stream->stream_slug), $this->input->get('order-'.$stream->stream_slug) ? $this->input->get('order-'.$stream->stream_slug) : 'ASC');
+			$this->db->order_by($this->input->get('order-'.$stream->stream_slug), $this->input->get('sort-'.$stream->stream_slug) ? $this->input->get('sort-'.$stream->stream_slug) : 'ASC');
 		}
 		elseif ($stream->sorting == 'title' and ($stream->title_column != '' and $this->db->field_exists($stream->title_column, $stream->stream_prefix.$stream->stream_slug)))
 		{


### PR DESCRIPTION
The query string sorting expained at the [streams->cp->entries_table()](http://docs.pyrocms.com/2.2/manual/developers/tools/streams-api/cp-driver#entries_table%28stream_slug,namespace_slug,pagination:null,pagination_uri:null,view_override:false,extra:array%29) docs were not working. The direction was always ASC. This fix corrects it.
