### PR TITLE
Search plugin and filter option

### DIFF
--- a/system/cms/modules/search/plugin.php
+++ b/system/cms/modules/search/plugin.php
@@ -122,8 +122,22 @@ class Plugin_Search extends Plugin
 		$segment = $this->attribute('page_segment', count(explode('/', $uri)) + 1);
 
 		// If it's POST, send it off to return as a GET
-		if ($this->input->post('q')) {
-			redirect($uri.'?q='.$this->input->post('q'));
+		if ($this->input->post('q'))
+		{
+			$uri .= "?q=".$this->input->post('q');
+			
+			//We need to check also the filter
+			if( $this->input->post('filter') )
+			{
+				$filter = $this->input->post('filter');
+
+				foreach( $filter as $key=>$value )
+				{
+					$uri .= "&filter[$key]=$value";
+				}								
+			}
+						
+			redirect($uri);
 		}
 
 		$query  = $this->input->get('q');


### PR DESCRIPTION
The current search plugin doesn't consider the filter option if the "uri" attrbiute is different from the default one.
With this simple fix the search work in both case.

What I have tried.
1. Insert a new record in search_index table with some keyword and associate it to a "Video" module.  
2. Use the double tag search form:

`{{ search:form class="search-form" }} 
    <input name="q" placeholder="Search terms..." />
    <input name="filter[video]" value="video:videos" type="hidden">
{{ /search:form }}`
1. Submit the form to the default search/result and it works.  
2. Redirect the default uri to a custom:

`{{ search:form class="search-form" action="video/search" }} 
    <input name="q" placeholder="Search terms..." />
    <input name="filter[video]" value="video:videos" type="hidden">
{{ /search:form }}`

and buil a view with a custom code and overwrite the uri:

`{{ search:results uri="video/ricerca" limit="10" }}`

and the search fails.  
With my fix both this operation works.

Please review this :)
