### PR TITLE
Correct redirect for Apache2 on Windows

### DIFF
--- a/system/cms/helpers/MY_url_helper.php
+++ b/system/cms/helpers/MY_url_helper.php
@@ -115,6 +115,11 @@ if ( ! function_exists('redirect'))
 		{
 			$uri = site_url($uri);
 		}
+		// IIS environment likely? Use 'refresh' for better compatibility
+		if ($method === 'auto' && isset($_SERVER['SERVER_SOFTWARE']) && strpos($_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS') !== FALSE)
+		{
+			$method = 'refresh';
+		}
 		elseif ($method !== 'refresh' && (empty($code) OR ! is_numeric($code)))
 		{
 			// Reference: http://en.wikipedia.org/wiki/Post/Redirect/Get


### PR DESCRIPTION
At Apache2/Windows redirect dont`t work correctly. Instead redirect happens refrash.
