### PR TITLE
fix double home page bug

### DIFF
--- a/system/cms/modules/pages/controllers/admin.php
+++ b/system/cms/modules/pages/controllers/admin.php
@@ -239,6 +239,7 @@ class Admin extends Admin_Controller {
 
 		$page['restricted_to'] = null;
 		$page['navigation_group_id'] = 0;
+		$page['is_home'] = 0;
 
 		$new_page = $this->page_m->create($page, $stream);
 


### PR DESCRIPTION
When doing a duplicate page, if we do that on a homepage, we end up having two homepages, which in result breaks the site until we edit required homepage and save it as 'is_home' once again.
