### PR TITLE
2.3/dev Insert bindings into queries displayed in the profiler

### DIFF
--- a/system/cms/libraries/Template.php
+++ b/system/cms/libraries/Template.php
@@ -374,7 +374,11 @@ class Template
 				// Log all queries using the profiler
 				foreach ($query_log as $query)
 				{
-				    ci()->profiler->log->query($query['query'], $query['time']);
+					// Insert bindings into query
+					$query['query'] = str_replace(array('%', '?'), array('%%', '%s'), $query['query']);
+					$query['query'] = vsprintf($query['query'], $query['bindings']);
+					
+					ci()->profiler->log->query($query['query'], $query['time']);
 				}
 
 				// Append the profiler to the body


### PR DESCRIPTION
i.e. We can see in the profiler... 

select \* from `default_data_fields` where `default_data_fields`.`id` in (3, 4, 5, 6, 7, 8, 9, 10, 11)

instead of...

select \* from `default_data_fields` where `default_data_fields`.`id` in (?, ?, ?, ?, ?, ?, ?, ?, ?)
