### PR TITLE
Template library: $name should be used as the array index in $this->_metadata and $this->_override_meta

### DIFF
--- a/system/cms/libraries/Template.php
+++ b/system/cms/libraries/Template.php
@@ -547,9 +547,9 @@ class Template
 				$link = '<link rel="'.$name.'" href="'.$content.'" />';
 
 				if ($override) {
-					$this->_override_meta[$place][$content] = $link;
+					$this->_override_meta[$place][$name] = $link;
 				} else {
-					$this->_metadata[$place][$content] = $link;
+					$this->_metadata[$place][$name] = $link;
 				}				
 			
 				break;


### PR DESCRIPTION
Meta tags with type 'link' were never being overwritten because it was using `$content` as the array key instead of `$name` in `_metadata[$place]` and `_override_meta[$place]`.

This was causing, for example, a duplicate canonical tag if attempting to overwrite the default one.
