### PR TITLE
issue #3084 solved, bug cannot use a stdObject as an array

### DIFF
--- a/system/cms/modules/streams_core/libraries/Fields.php
+++ b/system/cms/modules/streams_core/libraries/Fields.php
@@ -378,7 +378,7 @@ class Fields
 				{
 					$values[$stream_field->field_slug] = null;
 				}
-				elseif ( ! isset($_POST[$stream_field->field_slug]) and ! isset($_POST[$stream_field->field_slug.'[]']))
+				elseif (is_array($_POST) && ! isset($_POST[$stream_field->field_slug]) and ! isset($_POST[$stream_field->field_slug.'[]']))
 				{
 					// If this is a new entry and there is no post data,
 					// we see if:
@@ -411,11 +411,11 @@ class Fields
 
 					// There is the possibility that this could be an array
 					// post value, so we check for that as well.
-					if (isset($_POST[$stream_field->field_slug]))
+					if (is_array($_POST) && isset($_POST[$stream_field->field_slug]))
 					{
 						$values[$stream_field->field_slug] = $this->CI->input->post($stream_field->field_slug);
 					}
-					elseif (isset($_POST[$stream_field->field_slug.'[]']))
+					elseif (is_array($_POST) && isset($_POST[$stream_field->field_slug.'[]']))
 					{
 						$values[$stream_field->field_slug] = $this->CI->input->post($stream_field->field_slug.'[]');
 					}


### PR DESCRIPTION
The file Fields.php on system/cms/modules/streams_core/libraries/Fields.php has some problems with validation, so you just need to add is_array($POST) before doing isset($POST[$stream_field->field_slug]) on line 381 for example.
