### PR TITLE
Fixed bug in set_metadata(), with type 'link'

### DIFF
--- a/system/cms/libraries/Template.php
+++ b/system/cms/libraries/Template.php
@@ -547,9 +547,9 @@ class Template
 				$link = '<link rel="'.$name.'" href="'.$content.'" />';
 
 				if ($override) {
-					$this->_override_meta[$place][$content] = $link;
+					$this->_override_meta[$place][$name] = $link;
 				} else {
-					$this->_metadata[$place][$content] = $link;
+					$this->_metadata[$place][$name] = $link;
 				}				
 			
 				break;


### PR DESCRIPTION
Without this, you would not be able to override `cannonical` like this:

->set_metadata('canonical', $data['item']['url'][CURRENT_LANGUAGE], 'link', 'header', true);

it was setting invalid $keys, with would just produce double canonical links in the header
