### PR TITLE
fix for pages:url plugin loading and 'executing' the page it links to

### DIFF
--- a/system/cms/modules/pages/plugin.php
+++ b/system/cms/modules/pages/plugin.php
@@ -250,7 +250,7 @@ class Plugin_Pages extends Plugin
 	public function url()
 	{
 		$id   = $this->attribute('id');
-		$page = $this->pyrocache->model('page_m', 'get', array($id));
+		$page = $this->pyrocache->model('page_m', 'get', array($id, false));
 
 		return site_url($page ? $page->uri : '');
 	}


### PR DESCRIPTION
Fixes issue #3105.

Not loading the page data in the context of the pages:url module should pose no problem since the implementation only needs to access the page's URI.
