### PR TITLE
Removed assign by reference in path() in system/cms/plugins/theme.php

### DIFF
--- a/system/cms/plugins/theme.php
+++ b/system/cms/plugins/theme.php
@@ -396,7 +396,7 @@ class Plugin_Theme extends Plugin
 	 */
 	public function path()
 	{
-		$path = & rtrim($this->load->get_var('template_views'), '/');
+		$path = rtrim($this->load->get_var('template_views'), '/');
 
 		return preg_replace('#(\/views(\/web|\/mobile)?)$#', '', $path) . '/';
 	}


### PR DESCRIPTION
rtrim() returns a string and the variable $path was being set to said string by reference. This is throws: Runtime Notice - Only variables should be assigned by reference

I'm not sure of the original intent to pass by reference. Loader::get_var doesn't return a reference. 
