### PR TITLE
issue 3115: fix for breadcrumb logic loading and 'executing' all the par...

### DIFF
--- a/system/cms/modules/pages/controllers/pages.php
+++ b/system/cms/modules/pages/controllers/pages.php
@@ -7,7 +7,7 @@
  */
 class Pages extends Public_Controller
 {
-	
+
 	/**
 	 * Constructor method
 	 */
@@ -159,7 +159,7 @@ class Pages extends Public_Controller
 				{
 					$breadcrumb_segments[] = $segment;
 
-					$parents[] = $this->pyrocache->model('page_m', 'get_by_uri', array($breadcrumb_segments, true));
+					$parents[] = $this->pyrocache->model('page_m', 'get_by_uri', array($breadcrumb_segments, true, true));
 				}
 
 				// Cache for next time
@@ -241,7 +241,7 @@ class Pages extends Public_Controller
 		}
 
 		$js = $this->parser->parse_string($page->layout->js.$page->js, $this, true);
-		
+
 		// Add our page and page layout JS
 		if ($js)
 		{


### PR DESCRIPTION
#3115: Fix for breadcrumb logic loading and 'executing' all the parent pages. By setting the $simple_return parameter of the get_by_uri method, the actual loading bit of the page data is skipped which is not a problem since the breadcrumb logic only need the page title and URI which are both part of the basic page information.
