### PR TITLE
Fatal error: Using $this when not in object...

### DIFF
--- a/system/cms/src/Pyro/Cache/CacheCollection.php
+++ b/system/cms/src/Pyro/Cache/CacheCollection.php
@@ -55,8 +55,10 @@ class CacheCollection extends Collection
 
 		ci()->cache->forget($this->collectionKey);
 
-		ci()->cache->rememberForever($this->collectionKey, function() {
-			return $this->items;
+		$me = $this;
+
+		ci()->cache->rememberForever($this->collectionKey, function() use ($me) {
+			return $me->all();
 		});
 
 		return $this;


### PR DESCRIPTION
Hello,

fixed this: Fatal error: Using $this when not in object context in /var/www/vhosts/pyrocms23/public/system/cms/src/Pyro/Cache/CacheCollection.php on line 59 Call Stack: 0.0000 646848 1.

it appears during installation of 2.3. 
It is probably problem of closuers and php 5.3.

Also somehow I was not able to access the $me->items, so replaced with $me->all().

Install now went good.

but getting on frontpage:
ErrorException [ Notice ]: Undefined property: CI::$module_details

FCPATH/system/cms/libraries/MX/Controller.php [ 58 ]
