### PR TITLE
Added missing offset attribute in redirect_m->limit() call

### DIFF
--- a/system/cms/modules/redirects/controllers/admin.php
+++ b/system/cms/modules/redirects/controllers/admin.php
@@ -55,7 +55,8 @@ class Admin extends Admin_Controller
 		$this->template->pagination = create_pagination('admin/redirects/index', $total_rows);
 
 		// Using this data, get the relevant results
-		$this->template->redirects = $this->redirect_m->order_by('`from`')->limit($this->template->pagination['limit'])->get_all();
+		$this->template->redirects = $this->redirect_m->order_by('`from`')
+			->limit($this->template->pagination['limit'], $this->template->pagination['offset'])->get_all();
 		$this->template->build('admin/index');
 	}
 


### PR DESCRIPTION
I made some work with redirects module and the pagination wasn't working. I found out that offset attribute is missing in limit() method call.

Affected versions are 2.1 and 2.2. Everything seems fime in 2.3.
