### PR TITLE
Update admin_themes.php

### DIFF
--- a/system/cms/modules/addons/controllers/admin_themes.php
+++ b/system/cms/modules/addons/controllers/admin_themes.php
@@ -403,8 +403,8 @@ class Admin_themes extends Admin_Controller
         if ($options) {
             foreach ($options as $option) {
                 $pieces = explode('=', $option);
-				$value = array_shift($pieces);
-				$name = implode('=', $pieces);
+		$value = array_shift($pieces);
+		$name = implode('=', $pieces);
 				
                 // todo: Maybe we should remove the trim()'s
                 // since this will affect only people who have had the base


### PR DESCRIPTION
A simple explode doesn't allow for an option value to contain an equal sign. With this change, that cares about equal signs a little more, theme options can contain HTML. Consider the following theme:

class Theme_Xyz extends Theme
{
  ...

  public function __construct()
  {
      $files = glob(FCPATH.SHARED_ADDONPATH.'themes/xyz/img/option-images/*');
      $image_options = array('=None');

```
  foreach($files as $file) : 
     $clean_path = str_replace(FCPATH, '/', $file);
     $image_options[] = $clean_path.'=<img src="'.$clean_path.'" style="height:100px;">';
  endforeach;

  $this->options = array(
     ...,
     'image' => array(
        'title' => 'Image:',
        'description' => '',
        'type' => 'radio',
        'default' => '',
        'options' => implode('|', $image_options),
        'is_required' => false,
     ),
     ...,
  );
```

  }
  ...
}
