### PR TITLE
Added the ability to override $this->agent->is_mobile()

### DIFF
--- a/system/cms/libraries/MY_User_agent.php
+++ b/system/cms/libraries/MY_User_agent.php
@@ -42,18 +42,7 @@ class MY_User_agent extends CI_User_agent
 			return FALSE;
 		}
 
-		if ( ! $this->is_mobile)
-		{
-			return FALSE;
-		}
-
-		// No need to be specific, it's a mobile
-		if ($key === NULL)
-		{
-			return TRUE;
-		}
-
-		// Check for a specific robot
-		return (isset($this->mobiles[$key]) && $this->mobile === $this->mobiles[$key]);
+		// If the mobile override cookie is not set then we will return to the standard is_mobile function
+		return parent::is_mobile($key);
 	}
 }


### PR DESCRIPTION
This update will allow mobile website developers to easily add a "View full site" button to the footer by appending ?mobile_override to the current page url. The cookie will immediately expire so that when the user closes the browser and opens the page again it will resume operation in mobile mode.
