### PR TITLE
FIX: Added in required PHP constant value 'CDN_OFFER_URL

### DIFF
--- a/installer/config/constants.php
+++ b/installer/config/constants.php
@@ -92,3 +92,14 @@ unset($base_uri, $base_url);
 */
 
 define('CMS_VERSION', '2.2.0-rc1');
+
+/*
+|--------------------------------------------------------------------------
+| CDN Offer URL
+|--------------------------------------------------------------------------
+|
+| We have a link in the settings page to MaxCDN and our landing page
+|
+*/
+
+define('CDN_OFFER_URL', 'http://tracking.maxcdn.com/c/89350/3982/378?u=http%3A%2F%2Fwww.maxcdn.com%2Fpyrocms');


### PR DESCRIPTION
FIX: Added in required PHP constant value 'CDN_OFFER_URL' which was missing from the installer config causing the installation to complete but display a notice on environments where error reporting is enabled.

![screen shot 2014-04-25 at 15 09 27](https://cloud.githubusercontent.com/assets/511641/2801502/470c997e-cc83-11e3-9ac4-0e3a59eabe54.png)
