### PR TITLE
FIX: Added check to see if an admin user is attempting to search via ajax

### DIFF
--- a/system/cms/core/Admin_Controller.php
+++ b/system/cms/core/Admin_Controller.php
@@ -204,6 +204,12 @@ class Admin_Controller extends MY_Controller {
 				return true;
 			}
 
+            //if we are trying to search the admin area
+            if ($current_page == 'admin/search' && $this->permissions)
+            {
+                return true;
+            }
+
 			// Check if the current user can view that page
 			return array_key_exists($this->module, $this->permissions);
 		}


### PR DESCRIPTION
Users who can access the admin area but are not of the group 'admin' are unable to use the search functionality. 

This fix allows users with permission to view the admin area to also use the search functionality in the control panel. 

Users from the group 'users' that have no admin area permissions are still blocked from accessing this functionality.

Before fix when non admin group privileged users tried to use the search:

![screen shot 2014-04-25 at 15 21 06](https://cloud.githubusercontent.com/assets/511641/2801765/ab333aea-cc86-11e3-87ba-7c8344e81803.png)

After fix:

![screen shot 2014-04-25 at 15 20 13](https://cloud.githubusercontent.com/assets/511641/2801772/b7210030-cc86-11e3-8aea-245f74c7a4d2.png)
