### PR TITLE
Fix Files module issue that causes the wrong items to be shown

### DIFF
--- a/system/cms/modules/files/js/functions.js
+++ b/system/cms/modules/files/js/functions.js
@@ -1,7 +1,8 @@
 jQuery(function($){
 	var $search_results,
 		$folders_center,
-		$item_details;
+		$item_details,
+		content_interval;
 		// end function global vars
 
 	pyro.files.cache = {};
@@ -627,7 +628,6 @@ jQuery(function($){
 			post_data,
 			i = 0,
 			items = [],
-			content_interval,
 			current;
 
 		// let them know we're getting the stuff, it may take a second
@@ -664,6 +664,7 @@ jQuery(function($){
 				// so let's wipe it clean...
 				$('.folders-center').find('li').fadeOut('fast').remove();
 				$('.tipsy').remove();
+				clearInterval(content_interval);
 
 				// use the folder_id from results as we know that's numeric
 				folder_id = results.data.parent_id;


### PR DESCRIPTION
When a user selects a different folder while the current folder’s contents are in the process of being displayed (one at a time), the items that have not yet been displayed will appear in the newly selected folder. This resolves that issue.
