### PR TITLE
Add support for WYSIWYG theme options

### DIFF
--- a/system/cms/config/migration.php
+++ b/system/cms/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = true;
 |
 */
 
-$config['migration_version'] = 129;
+$config['migration_version'] = 130;
 
 /*
 |--------------------------------------------------------------------------

--- a/system/cms/migrations/130_Alter_theme_options.php
+++ b/system/cms/migrations/130_Alter_theme_options.php
@@ -1,0 +1,29 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Migration 130: Alter theme options
+ *
+ * This allows us to use larger strings for theme options
+ * and adds support for WYSIWYG fields for theme options.
+ */
+
+class Migration_Alter_theme_options extends CI_Migration {
+
+  public function up()
+  {
+     $this->dbforge->modify_column('theme_options', array(
+        'default' => array('type'  => 'TEXT'),
+        'value' => array('type'  => 'TEXT'),
+        'type' => array('type' => "SET('text','textarea','password','select','select-multiple','radio','checkbox','colour-picker','wysiwyg')", 'null' => false)
+      ));
+  }
+
+  public function down()
+  {
+    $this->dbforge->modify_column('theme_options', array(
+      'default' => array('type' => 'varchar', 'constraint' => 255),
+      'value' => array('type' => 'varchar', 'constraint' => 255),
+      'type' => array('type' => "SET('text','textarea','password','select','select-multiple','radio','checkbox','colour-picker')", 'null' => false)
+    ));
+  }
+}

--- a/system/cms/modules/addons/controllers/admin_themes.php
+++ b/system/cms/modules/addons/controllers/admin_themes.php
@@ -147,10 +147,11 @@ class Admin_themes extends Admin_Controller
 		$data->options_array = $all_options;
 		$data->controller = &$this;
 
-		$this->template->append_js('module::jquery.minicolors.min.js');
-		$this->template->append_css('module::jquery.minicolors.css');
-
-		$this->template->build('admin/themes/options', $data);
+		$this->template
+			->append_js('module::jquery.minicolors.min.js')
+			->append_css('module::jquery.minicolors.css')
+			->append_metadata($this->load->view('fragments/wysiwyg', array(), true))
+			->build('admin/themes/options', $data);
 	}
 
 	/**
@@ -432,6 +433,15 @@ class Admin_themes extends Admin_Controller
 					'name' => $option->slug,
 					'value' => $option->value,
 					'class' => 'text width-20 colour-picker'
+				));
+				break;
+
+			case 'wysiwyg':
+				$form_control = form_textarea(array(
+					'id' => $option->slug,
+					'name' => $option->slug,
+					'value' => $option->value,
+					'class' => 'wysiwyg-advanced'
 				));
 				break;
 		}


### PR DESCRIPTION
This allows theme developers to add WYSIWYG theme option fields that could be used for things like a custom branded footer or other site-wide chunks of markup.

This update includes a migration that changes the `default` and `value` columns in the **theme_options** table from type `VARCHAR` to `TEXT`, allowing for larger string values, like blocks of HTML.
