### PR TITLE
2.2/ogv support

### DIFF
--- a/system/cms/config/mimes.php
+++ b/system/cms/config/mimes.php
@@ -135,6 +135,7 @@ return array('hqx'	=>	array('application/mac-binhex40', 'application/mac-binhex'
 				'ac3'   =>	'audio/ac3',
 				'flac'  =>	'audio/x-flac',
 				'ogg'   =>	'audio/ogg',
+				'ogv' => 'application/ogg',
 				'pages' =>      'application/zip',
 				'numbers' =>    'application/zip',
 				'svg'  =>	'image/svg+xml',

--- a/system/cms/modules/files/config/files.php
+++ b/system/cms/modules/files/config/files.php
@@ -9,7 +9,7 @@ $config['files:encrypt_filename'] = true;
 
 $config['files:allowed_file_ext'] = array(
 	'a'	=> array('mpga', 'mp2', 'mp3', 'ra', 'rv', 'wav'),
-	'v'	=> array('mpeg', 'mpg', 'mpe', 'mp4', 'flv', 'qt', 'mov', 'avi', 'movie'),
+	'v'	=> array('mpeg', 'mpg', 'mpe', 'mp4', 'flv', 'qt', 'mov', 'avi', 'movie', 'ogv'),
 	'd'	=> array('pdf', 'xls', 'ppt', 'pptx', 'txt', 'text', 'log', 'rtx', 'rtf', 'xml', 'xsl', 'doc', 'docx', 'xlsx', 'word', 'xl', 'csv', 'pages', 'numbers'),
 	'i'	=> array('bmp', 'gif', 'jpeg', 'jpg', 'jpe', 'png', 'tiff', 'tif'),
 	'o'	=> array('psd', 'gtar', 'swf', 'tar', 'tgz', 'xhtml', 'zip', 'css', 'html', 'htm', 'shtml', 'svg'),


### PR DESCRIPTION
This has been plaguing me for quite some time and I finally got it figured out. The problem is with the fun mime type that gets tossed around for OGV.

Anyone here would say, "oh well ogv? that's a mime type of video/ogg! Everyone and their grandma knows that!". Well yeah, but it turns out the server is often wrong. I tried [using this page](http://wiki.xiph.org/index.php/MIME_Types_and_File_Extensions) to attempt to assign the correct mime type, but nothing was working.

This [stackoverflow answer](http://stackoverflow.com/a/10850763) helped me solve this issue. If you [go to this line](https://github.com/pyrocms/pyrocms/blob/2.2/master/system/codeigniter/libraries/Upload.php#L218) in the CodeIgniter uploads class, and change that line to the following:

``` php
$this->_file_mime_type($_FILES[$field]); var_dump($this->file_type); die();
```

Then check your ajax response on the `upload` POST function if the files upload, you will see the `var_dump` of the _REAL_ mime type that the server is returning. In this case it was returning `application/ogg`!

In summation, this mime type is needed to upload videos for Firefox, since they [cannot play mp4 due to licensing](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats#MP4_H.264_%28AAC_or_MP3%29). Hopefully in the future everything will be [webm video](http://www.webmproject.org/).

**Sidenote**

I am using the default .htaccess. Modifying it and adding the mime type of `video/ogg` may mean you need to update the mimes.php file to reflect that change. But for now, this is what worked for me.
