### PR TITLE
Order link children by their position

### DIFF
--- a/system/cms/modules/navigation/src/Pyro/Module/Navigation/Model/Link.php
+++ b/system/cms/modules/navigation/src/Pyro/Module/Navigation/Model/Link.php
@@ -47,7 +47,7 @@ class Link extends Eloquent
      */
     public function children()
     {
-        return $this->hasMany('Pyro\Module\Navigation\Model\Link', 'parent');
+        return $this->hasMany('Pyro\Module\Navigation\Model\Link', 'parent')->orderBy('position', 'ASC');
     }
 
     /**


### PR DESCRIPTION
This fixes an issue where links in deeper levels of the navigation tree aren't ordered by their position.
