### PR TITLE
fixed dashboard notice

### DIFF
--- a/system/cms/src/Pyro/Model/EloquentCollection.php
+++ b/system/cms/src/Pyro/Model/EloquentCollection.php
@@ -73,7 +73,7 @@ class EloquentCollection extends Collection
     {
         $this->each(
             function ($model) {
-                $model->delete();
+                $model->save();
             }
         );
     }

--- a/system/cms/themes/pyrocms/views/admin/dashboard.php
+++ b/system/cms/themes/pyrocms/views/admin/dashboard.php
@@ -3,9 +3,9 @@
 
 	<!-- Dashboard Widgets -->
 	{{ widgets:area slug="dashboard" }}
-	
+
 	<!-- Begin Quick Links -->
-	<?php if ($theme_options->pyrocms_quick_links == 'yes'): ?>
+	<?php if ($theme_options and isset($theme_options->pyrocms_quick_links) and $theme_options->pyrocms_quick_links === 'yes'): ?>
 	<div class="one_full">
 		
 		<section class="draggable title">


### PR DESCRIPTION
fixed dashboard notice (on fresh install 2.3 beta, $theme_options is empty object)

Also, the system/cms/src/Pyro/Model/EloquentCollection.php has this method:

``` php
    public function save()
    {
        $this->each(
            function ($model) {
                $model->delete();
            }
        );
    }
```

changed delete to 'save()', probably it's a valid fix?

Thanks
