### PR TITLE
Fix image field type validation.

### DIFF
--- a/system/cms/modules/streams_core/field_types/image/field.image.php
+++ b/system/cms/modules/streams_core/field_types/image/field.image.php
@@ -35,7 +35,7 @@ class Field_image
 	public function event()
 	{
 		$this->CI->type->add_js('image', 'imagefield.js');
-		$this->CI->type->add_css('image', 'imagefield.css');		
+		$this->CI->type->add_css('image', 'imagefield.css');
 	}
 
 	// --------------------------------------------------------------------------
@@ -330,7 +330,7 @@ class Field_image
 
 	/**
 	 * Input validation
-	 * 
+	 *
 	 * @param  mixed - string or null $value
 	 * @param  string - edit  or new  $mode
 	 * @param  object                 $field
@@ -338,7 +338,10 @@ class Field_image
 	 */
 	public function validate($value, $mode, $field)
 	{
-		if (isset($_FILES[$field->field_slug . '_file']))
+		$image_file = $_FILES[$field->field_slug . '_file'];
+
+		// check if the user uploaded a new file
+		if (is_array($image_file) && isset($image_file['name']) && $image_file['name'] != '')
 		{
 			$allowed_types = explode('|', $field->field_data['allowed_types']);
 			$filename      = $_FILES[$field->field_slug . '_file']['name'];
@@ -346,7 +349,7 @@ class Field_image
 
 			if ( ! in_array($extension, $allowed_types))
 			{
-				return sprintf(lang('streams:image.allowed_types_error'), $field->field_name);
+				return sprintf(sprintf(lang('streams:image.allowed_types_error'), implode(", ", $allowed_types)), $field->field_name);
 			}
 		}
 

--- a/system/cms/modules/streams_core/field_types/image/language/english/image_lang.php
+++ b/system/cms/modules/streams_core/field_types/image/language/english/image_lang.php
@@ -10,3 +10,4 @@ $lang['streams:image.need_folder']		= 'You need to set an upload folder before y
 $lang['streams:image.keep_ratio'] 		= 'Keep Ratio';
 $lang['streams:image.keep_ratio_instr']		= 'When resizing, should we keep the ratio?';
 $lang['streams:image.allowed_types_instr'] 	= 'Ex: jpg|jpeg|png';
+$lang['streams:image.allowed_types_error'] 	= 'The image type is not allowed. Allowed types: %s.';

--- a/system/cms/modules/streams_core/field_types/image/language/german/image_lang.php
+++ b/system/cms/modules/streams_core/field_types/image/language/german/image_lang.php
@@ -10,3 +10,4 @@ $lang['streams:image.need_folder']		= 'Du musst ein Uploadverzeichnis festlegen,
 $lang['streams:image.keep_ratio'] 		= 'Seitenverhältnis beibehalten';
 $lang['streams:image.keep_ratio_instr']		= 'Soll das Seitenverhältnis bei einer Größenänderung beibehalten werden?';
 $lang['streams:image.allowed_types_instr'] 	= 'Dateitypen: jpg|jpeg|png';
+$lang['streams:image.allowed_types_error'] 	= 'Das Bildformat ist nicht erlaubt. Erlaubte Bildformate: %s.';


### PR DESCRIPTION
This fixes a bug where the image field's file input is included in the request's POST data, even when the user didn't upload a new file. This caused the validation to fail with a missing language key and thus no visible error for the user, creating the appearance that the page was saved when it was in fact not.
