### PR TITLE
Fixed page type sync cache issue.

### DIFF
--- a/system/cms/modules/pages/controllers/admin_types.php
+++ b/system/cms/modules/pages/controllers/admin_types.php
@@ -496,7 +496,7 @@ class Admin_types extends Admin_Controller
  		else
  		{
 			$this->session->set_flashdata('success', lang('page_types:sync_success'));
-			$this->pyrocache->delete_all('page_m');
+			$this->pyrocache->delete_all('page_type_m');
 			Events::trigger('page_type_updated', $page_type->id);
  		}
 


### PR DESCRIPTION
When hitting the sync button, after editing a page type layout on the file system, the cache for pages was being cleared and not the one for page_type_m.
