### PR TITLE
Update is_mobile to detect ipad/tablets correcty

### DIFF
--- a/system/cms/libraries/MY_User_agent.php
+++ b/system/cms/libraries/MY_User_agent.php
@@ -42,6 +42,11 @@ class MY_User_agent extends CI_User_agent
 			return FALSE;
 		}
 
+		// If mobile is set and contains generic, but desktop is also set (as is the case with the iPad) then prefer desktop
+		if((stripos(parent::mobile(), 'generic') !== false) && parent::is_browser($key)) {
+			return FALSE;
+		}
+
 		return parent::is_mobile($key);
 	}
 }


### PR DESCRIPTION
Update is_mobile function to properly detect devices that return true for is_mobile and is_browser. Will prefer desktop if is_mobile and is_desktop both return true, but only if mobile is returned as something "Generic"
