### PR TITLE
Update is_mobile to treat iPad specially. It is the only tablet that I k...

### DIFF
--- a/system/cms/libraries/MY_User_agent.php
+++ b/system/cms/libraries/MY_User_agent.php
@@ -39,12 +39,14 @@ class MY_User_agent extends CI_User_agent
 	public function is_mobile($key = null)
 	{
 		// If the mobile override cookie is set then ignore is_mobile and just return false
-		if(isset($_COOKIE['mobile_override'])) {
+		if(isset($_COOKIE['mobile_override']))
+		{
 			return FALSE;
 		}
 
 		// Dumb, but iPad needs special consideration to be considered a desktop device.
-		if(parent::browser() == 'iPad') {
+		if(parent::browser() == 'iPad')
+		{
 			return FALSE;
 		}
 


### PR DESCRIPTION
...now of that renders as a mobile device rather than a desktop, as it should. Tested on iPad, iPhone, Android Phone, Android Tablet, and Windows Phone
