### PR TITLE
Fix that allows an update to the stream slug

### DIFF
--- a/system/cms/libraries/Streams/drivers/Streams_streams.php
+++ b/system/cms/libraries/Streams/drivers/Streams_streams.php
@@ -139,7 +139,7 @@ class Streams_streams extends CI_Driver {
 		
 		if ( ! $str_id) $this->log_error('invalid_stream', 'update_stream');
 		
-		$data['stream_slug'] = $stream;
+		$data['stream_slug'] = isset($data['stream_slug']) ? $data['stream_slug'] : $stream;
 
 		return $this->CI->streams_m->update_stream($str_id, $data);
 	}


### PR DESCRIPTION
I don't think I have ever figures out why the slug and table name would not update until now. The docs show you can update the slug. I looked at this file and noticed that the $stream parameter was sent to the update method no matter if the $data param contained a new slug or not. I made this update and everything seems to work now.
