### PR TITLE
Small changes to improve the core

### DIFF
--- a/system/cms/core/MY_Controller.php
+++ b/system/cms/core/MY_Controller.php
@@ -166,7 +166,7 @@ class MY_Controller extends MX_Controller
 				// Set meta data for the module to be accessible system wide
 				$this->template->module_details = ci()->module_details = $this->module_details = $module;
 
-				continue;
+				break;
 			}
 		}
 

--- a/system/cms/modules/addons/models/module_m.php
+++ b/system/cms/modules/addons/models/module_m.php
@@ -100,12 +100,12 @@ class Module_m extends MY_Model
 				'is_frontend' => $row->is_frontend,
 				'is_backend' => $row->is_backend,
 				'menu' => $row->menu,
-				'enabled' => $row->enabled,
+				'enabled' => (int)$row->enabled,
 				'sections' => ! empty($info['sections']) ? $info['sections'] : array(),
 				'shortcuts' => ! empty($info['shortcuts']) ? $info['shortcuts'] : array(),
 				'is_core' => $row->is_core,
-				'is_current' => version_compare($row->version, $this->version($row->slug),  '>='),
-				'current_version' => $this->version($row->slug),
+				'is_current' => version_compare($row->version, $class->version,  '>='),
+				'current_version' => $class->version,
 				'path' => $location,
 				'updated_on' => $row->updated_on
 			);
@@ -183,8 +183,8 @@ class Module_m extends MY_Model
 				'shortcuts'       => ! empty($info['shortcuts']) ? $info['shortcuts'] : array(),
 				'installed'       => $row->installed,
 				'is_core'         => $row->is_core,
-				'is_current'      => version_compare($row->version, $this->version($row->slug),  '>='),
-				'current_version' => $this->version($row->slug),
+				'is_current'      => version_compare($row->version, $class->version,  '>='),
+				'current_version' => $class->version,
 				'path'            => $location,
 				'updated_on'      => $row->updated_on
 			);

--- a/system/cms/modules/streams_core/field_types/choice/field.choice.php
+++ b/system/cms/modules/streams_core/field_types/choice/field.choice.php
@@ -36,7 +36,9 @@ class Field_choice
 	 * @var 	array
 	 */
 	public $input_types = array('dropdown', 'multiselect', 'radio', 'checkboxes');
-		
+	
+	public $extra_validation = "trim";
+	
 	// --------------------------------------------------------------------------
 
 	/**
@@ -307,9 +309,9 @@ class Field_choice
 		if (($field->field_data['choice_type'] == 'checkboxes' or $field->field_data['choice_type'] == 'multiselect') and is_array($value))
 		{
 			// Go through and count the number that are disabled
-			$choices = explode("\n", $field->field_data['choice_data']);
+			$lines = explode("\n", $field->field_data['choice_data']);
 
-			foreach($choices as $choice_line)
+			foreach($lines as $choice_line)
 			{
 				$choice_line = trim($choice_line);
 
@@ -372,6 +374,16 @@ class Field_choice
 			}
 
 		}
+		
+        //Get all choices array([choice] => Title)
+        $choices = $this->_choices_to_array($field->field_data['choice_data'], null);
+        //$value can be either array() or string
+        foreach((array)$value as $v){
+            if(!isset($choices[trim($v)])){
+                //Something isn't right
+                return lang('streams:choice.invalidtype');
+            }
+        }
 
 		return true;
 	}

--- a/system/cms/modules/streams_core/field_types/choice/language/brazilian/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/brazilian/choice_lang.php
@@ -14,3 +14,4 @@ $lang['streams:choice.must_select_num'] 	= 'Você deve selecionar {val} itens da
 $lang['streams:choice.must_at_least'] 		= 'Você deve selecionar pelo menos {val} itens da lista %s.';
 $lang['streams:choice.must_max_num'] 		= 'Você pode selecionar apenas {val} itens da lista %s.';
 $lang['streams:choice.multiselect'] 		= 'Tipo Multiseleção.';
+$lang['streams:choice.invalidtype'] 		= 'Tipo inválido.';

--- a/system/cms/modules/streams_core/field_types/choice/language/czech/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/czech/choice_lang.php
@@ -13,4 +13,5 @@ $lang['streams:choice.checkboxes_only'] 	= 'Only available for checkboxes.'; #tr
 $lang['streams:choice.must_select_num'] 	= 'You must select {val} items from the %s list.';				#translate
 $lang['streams:choice.must_at_least'] 		= 'You must select at least {val} items from the %s list.';		#translate
 $lang['streams:choice.must_max_num'] 		= 'You can only select {val} items from the %s list.';			#translate
-$lang['streams:choice.multiselect'] 		= 'Multiselect Type.'; 											#translate
+$lang['streams:choice.multiselect'] 		= 'Multiselect Type.';#translate 	
+$lang['streams:choice.invalidtype'] 		= 'Invalid Type.';#translate

--- a/system/cms/modules/streams_core/field_types/choice/language/english/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/english/choice_lang.php
@@ -14,3 +14,4 @@ $lang['streams:choice.must_select_num'] 	= 'You must select {val} items from the
 $lang['streams:choice.must_at_least'] 		= 'You must select at least {val} items from the %s list.';
 $lang['streams:choice.must_max_num'] 		= 'You can only select {val} items from the %s list.';
 $lang['streams:choice.multiselect'] 		= 'Multiselect Type.';
+$lang['streams:choice.invalidtype'] 		= 'Invalid Type.';

--- a/system/cms/modules/streams_core/field_types/choice/language/french/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/french/choice_lang.php
@@ -14,3 +14,4 @@ $lang['streams:choice.must_select_num'] 	= 'Vous devez sélectionner {val} élé
 $lang['streams:choice.must_at_least'] 		= 'Vous devez au moins sélectionner {val} éléments de la liste %s.';
 $lang['streams:choice.must_max_num'] 		= 'Vous ne pouvez sélectionner que {val} éléments de la liste %s.';
 $lang['streams:choice.multiselect'] 		= 'Selection multiple.';
+$lang['streams:choice.invalidtype'] 		= 'Invalid Type.';#translate

--- a/system/cms/modules/streams_core/field_types/choice/language/german/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/german/choice_lang.php
@@ -14,3 +14,4 @@ $lang['streams:choice.must_select_num'] 	= 'You must select {val} items from the
 $lang['streams:choice.must_at_least'] 		= 'You must select at least {val} items from the %s list.';		#translate
 $lang['streams:choice.must_max_num'] 		= 'You can only select {val} items from the %s list.';			#translate
 $lang['streams:choice.multiselect'] 		= 'Multiselect Type.'; 											#translate
+$lang['streams:choice.invalidtype'] 		= 'Invalid Type.';#translate

--- a/system/cms/modules/streams_core/field_types/choice/language/greek/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/greek/choice_lang.php
@@ -14,3 +14,4 @@ $lang['streams:choice.must_select_num'] 	= 'Πρέπει να επιλέξετε
 $lang['streams:choice.must_at_least'] 		= 'Πρέπει να επιλέξετε τουλάχιστον {val} στοιχεία από την λίστα %s.';
 $lang['streams:choice.must_max_num'] 		= 'Μπορείτε να επιλέξετε μόνο {val} στοιχεία από την λίστα %s.';
 $lang['streams:choice.multiselect'] 		= 'Τύπος Πολλαπλών Επιλογών.';
+$lang['streams:choice.invalidtype'] 		= 'Invalid Type.';#translate

--- a/system/cms/modules/streams_core/field_types/choice/language/hungarian/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/hungarian/choice_lang.php
@@ -14,5 +14,5 @@ $lang['streams:choice.must_select_num'] = 'Muszáj kiválasztanod {val} tételt 
 $lang['streams:choice.must_at_least']   = 'Muszáj kiválasztanod legalább {val} tételt a %s listából.';
 $lang['streams:choice.must_max_num']    = 'Csak {val} tételt választhatsz ki a %s listából.';
 $lang['streams:choice.multiselect'] 		= 'Multiselect Type.'; 											#translate
-
+$lang['streams:choice.invalidtype'] 		= 'Invalid Type.';#translate
 /* End of file choice_lang.php */

--- a/system/cms/modules/streams_core/field_types/choice/language/lithuanian/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/lithuanian/choice_lang.php
@@ -14,3 +14,4 @@ $lang['streams:choice.must_select_num'] 	= 'You must select {val} items from the
 $lang['streams:choice.must_at_least'] 		= 'You must select at least {val} items from the %s list.';		#translate
 $lang['streams:choice.must_max_num'] 		= 'You can only select {val} items from the %s list.';			#translate
 $lang['streams:choice.multiselect'] 		= 'Multiselect Type.'; 											#translate
+$lang['streams:choice.invalidtype'] 		= 'Invalid Type.';#translate

--- a/system/cms/modules/streams_core/field_types/choice/language/spanish/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/spanish/choice_lang.php
@@ -14,3 +14,4 @@ $lang['streams:choice.must_select_num'] 	= 'You must select {val} items from the
 $lang['streams:choice.must_at_least'] 		= 'You must select at least {val} items from the %s list.';		#translate
 $lang['streams:choice.must_max_num'] 		= 'You can only select {val} items from the %s list.';			#translate
 $lang['streams:choice.multiselect'] 		= 'Multiselect Type.'; 											#translate
+$lang['streams:choice.invalidtype'] 		= 'Invalid Type.';#translate

--- a/system/cms/modules/streams_core/field_types/choice/language/swedish/choice_lang.php
+++ b/system/cms/modules/streams_core/field_types/choice/language/swedish/choice_lang.php
@@ -25,7 +25,7 @@ $lang['streams:choice.checkboxes_only'] 	= 'Only available for checkboxes.'; #tr
 $lang['streams:choice.must_select_num'] 	= 'You must select {val} items from the %s list.';				#translate
 $lang['streams:choice.must_at_least'] 		= 'You must select at least {val} items from the %s list.';		#translate
 $lang['streams:choice.must_max_num'] 		= 'You can only select {val} items from the %s list.';			#translate
-
+$lang['streams:choice.invalidtype'] 		= 'Invalid Type.';#translate
 
 /* End of file choice_lang.php */  
 /* Location: ./system/cms/modules/streams_core/field_types/choice/language/swedish */ 

--- a/system/cms/modules/streams_core/libraries/Fields.php
+++ b/system/cms/modules/streams_core/libraries/Fields.php
@@ -121,7 +121,7 @@ class Fields
 		{
 			// Note that we don't check to see if the variable has
 			// a non-null value, since the $extra variables can
-			// be set to null. 
+			// be set to null.
 			if ( ! isset($extra[$key])) $extra[$key] = $value;
 		}
 
@@ -227,7 +227,9 @@ class Fields
 				{
 					if ( ! $result_id = $this->CI->row_m->insert_entry($_POST, $stream_fields, $stream, $skips))
 					{
-						$this->CI->session->set_flashdata('notice', $this->CI->fields->translate_label($failure_message));
+                        if($extra['failure_message'] !== false){
+                            $this->CI->session->set_flashdata('notice', $this->CI->fields->translate_label($extra['failure_message']));
+                        }
 					}
 					else
 					{
@@ -244,8 +246,9 @@ class Fields
 						}
 		
 						// -------------------------------------
-					
-						$this->CI->session->set_flashdata('success', $this->CI->fields->translate_label($extra['success_message']));
+                        if($extra['success_message'] !== false){
+                            $this->CI->session->set_flashdata('success', $this->CI->fields->translate_label($extra['success_message']));
+                        }
 					}
 				}
 				else
@@ -258,7 +261,9 @@ class Fields
 														$skips
 													))
 					{
-						$this->CI->session->set_flashdata('notice', $this->CI->fields->translate_label($extra['failure_message']));	
+                        if($extra['failure_message'] !== false){
+                            $this->CI->session->set_flashdata('notice', $this->CI->fields->translate_label($extra['failure_message']));	
+                        }
 					}
 					else
 					{
@@ -275,8 +280,9 @@ class Fields
 						}
 		
 						// -------------------------------------
-					
-						$this->CI->session->set_flashdata('success', $this->CI->fields->translate_label($extra['success_message']));
+                        if($extra['success_message'] !== false){
+                            $this->CI->session->set_flashdata('success', $this->CI->fields->translate_label($extra['success_message']));
+                        }
 					}
 				}
 			


### PR DESCRIPTION
My proposed changes:

1) Few lines in module_m.php that I thought could be improved for performance.

2) A plain distraction bug on MY_Controller.php.

3) On streams_core/libraries/Fields.php I made a very small change to make stream inserts friendly for ajax requests by being able to avoid insertion of messages to flashvars by giving them FALSE.
Also streams_core/libraries/Fields.php:230, had a wrong variable in use regardless of my changes:

$this->CI->session->set_flashdata('notice', $this->CI->fields->translate_label($failure_message));

Should be

$this->CI->session->set_flashdata('notice', $this->CI->fields->translate_label($extra['failure_message']));

Regards.

Edit: Patch for the Stream field_type Choice that will validate if the values submitted are valid.