### PR TITLE
Fix warning in php 5.6 Laravel Forge Server.

### DIFF
--- a/system/codeigniter/core/Common.php
+++ b/system/codeigniter/core/Common.php
@@ -268,8 +268,8 @@ if ( ! function_exists('get_config'))
 				}
 			}
 		}
-
-		return $_config[0] =& $config;
+                $_config[0] =& $config;
+		return $_config[0];
 	}
 }
 


### PR DESCRIPTION
Testing PyroCMS in php 5.6 in Laravel forge, I got the warning "Only variable references should be returned by reference" in file core/common line 272.  this fixes the warning
