### PR TITLE
Make redirect_m::get_from case sensitive

### DIFF
--- a/system/cms/modules/redirects/models/redirect_m.php
+++ b/system/cms/modules/redirects/models/redirect_m.php
@@ -23,10 +23,13 @@ class Redirect_m extends MY_Model
 
 	public function get_from($from)
 	{
-		return $this->db
+		$res = $this->db
 			->like('from', $from, 'none')
 			->get($this->_table)
 			->row();
+
+		if(is_object($res) && $res->from === $from) return $res;
+		return NULL;
 	}
 
 	public function count_all()


### PR DESCRIPTION
Ran into an issue where the url "APPLY" was being visited, it would 404 as the slug was "apply" - Created a redirect rule to remedy the situation but it ended up just looping because there was no case sensitivity awareness.
