### PR TITLE
fix theme options so they reflect 2.2 and 2.3 docs

### DIFF
--- a/system/cms/core/Public_Controller.php
+++ b/system/cms/core/Public_Controller.php
@@ -99,15 +99,10 @@ class Public_Controller extends MY_Controller
 		// Assign segments to the template the new way
 		$this->template->server = $_SERVER;
 
-        // Set the theme option values
-        foreach ($this->theme->model->options as $option) {
-            foreach ($this->theme->options as &$themeOption) {
-                if (isset($themeOption['slug']) and $themeOption['slug'] == $option->slug) {
-                    $themeOption = $option->value;
-                }
-            }
-        }
-
+		// Set the theme option values
+		foreach ($this->theme->model->options as $options) {
+			$this->theme->options[$options->slug] = $options->value;
+		}
 		$this->template->theme = $this->theme;
 
 		$this->benchmark->mark('public_controller_end');


### PR DESCRIPTION
I believe #3376 was prematurely closed. I just installed a fresh version of 2.3/develop and `{{ theme:options:option_slug }}` throws an **Array to string conversion error**.

The problem here was `$this->theme->options` (referenced by `$themeOption`) **has no slug**. You are populating `$this->theme->options`, so it would never have a slug.

My loop takes all the model options and binds them to the appropriate `key(slug) => value` sets. This returns the functionality of `{{ theme:options:option_slug }}` to what is expected from the docs.
