### PR TITLE
2.2/fix button icon

### DIFF
--- a/system/cms/themes/pyrocms/css/workless/application.css
+++ b/system/cms/themes/pyrocms/css/workless/application.css
@@ -298,7 +298,6 @@ margin-top: -4px;
   font-weight: 700;
   color: #fff;
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.8);
-  vertical-align: middle;
   content: '+ ';
 }
 
@@ -625,7 +624,7 @@ margin-top: -4px;
 	font-size: 10px;
 	font-weight: bold;
 	text-transform: uppercase;
-	
+
 }
 
 #widget-comments .comments-gravatar {


### PR DESCRIPTION
This has been killing me for a while. I finally decided to inspect. Removing the `vertical-align: middle;` corrects the position.

Before:

![screen shot 2014-12-04 at 10 48 22 am](https://cloud.githubusercontent.com/assets/1425304/5301074/954e4b62-7ba3-11e4-8dc7-5eace38d9747.png)

After:

![screen shot 2014-12-04 at 10 48 40 am](https://cloud.githubusercontent.com/assets/1425304/5301075/9564867a-7ba3-11e4-860a-017af968d921.png)
