### PR TITLE
2.2/add loading gif when in page index

### DIFF
--- a/system/cms/modules/pages/css/index.css
+++ b/system/cms/modules/pages/css/index.css
@@ -79,8 +79,24 @@
 	background:url(../img/less.png) no-repeat 0 7px;
 }
 
+.content.loading {
+	background-image: url(../../../themes/pyrocms/img/admin/loading.gif);
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	border: none;
+}
+
 #page-details {
-	min-height:250px;
+	min-height: 250px;
+	opacity: 1;
+	-webkit-transition: 250ms ease opacity;
+	-moz-transition: 250ms ease opacity;
+	-o-transition: 250ms ease opacity;
+	transition: 250ms ease opacity;
+}
+
+.content.loading #page-details {
+	opacity: 0;
 }
 
 #page-details h5 {

--- a/system/cms/modules/pages/js/index.js
+++ b/system/cms/modules/pages/js/index.js
@@ -29,7 +29,7 @@
 				$content.removeClass('loading');
 			});
 
-			$details.parent().prev('section.title').html( $('<h4 />').text(page_title) );
+			$content.prev('section.title').html( $('<h4 />').text(page_title) );
 
 			// return false to keep the list from toggling when link is clicked
 			return false;

--- a/system/cms/modules/pages/js/index.js
+++ b/system/cms/modules/pages/js/index.js
@@ -9,10 +9,12 @@
 		// store some common elements
 		$details 	= $('div#page-details');
 		$details_id	= $('div#page-details #page-id');
+		$content = $details.parent();
 
 		// show the page details pane
 		$item_list.find('li a').live('click', function(e) {
 			e.preventDefault();
+			$content.addClass('loading');
 
 			$a = $(this);
 
@@ -24,6 +26,7 @@
 			// Load the details box in
 			$details.load(SITE_URL + 'admin/pages/ajax_page_details/' + page_id, function(){
 				refresh_sticky_page_details(true);
+				$content.removeClass('loading');
 			});
 
 			$details.parent().prev('section.title').html( $('<h4 />').text(page_title) );


### PR DESCRIPTION
![page-index-feedback](https://cloud.githubusercontent.com/assets/1425304/7123593/3cb7ddc4-e1f1-11e4-8ff9-8caf81b3c3e6.gif)

This PR adds a loading gif for when the page details are loading in the page index. I find this to be really useful for user feedback. Most of the time they may not know anything is happening.
