### PR TITLE
2.2/wysiwyg empty starting p

### DIFF
--- a/system/cms/modules/streams_core/field_types/wysiwyg/field.wysiwyg.php
+++ b/system/cms/modules/streams_core/field_types/wysiwyg/field.wysiwyg.php
@@ -60,6 +60,10 @@ class Field_wysiwyg
 
 		$parse_tags = ( ! isset($params['allow_tags'])) ? 'n' : $params['allow_tags'];
 
+		if ($input == '<p></p>') {
+			$input = '';
+		}
+
 		// If this isn't the admin and we want to allow tags,
 		// let it through. Otherwise we will escape them.
 		if ( ! defined('ADMIN_THEME') and $parse_tags == 'y')

--- a/system/cms/modules/streams_core/field_types/wysiwyg/field.wysiwyg.php
+++ b/system/cms/modules/streams_core/field_types/wysiwyg/field.wysiwyg.php
@@ -94,7 +94,10 @@ class Field_wysiwyg
 		{
 			$options['class']	= 'wysiwyg-simple';
 		}
-	
+		// if empty, add an empty p tag to avoid formatting errors
+		if (empty($data['value'])) {
+			$data['value'] = '<p></p>';
+		}
 		$options['name'] 	= $data['form_slug'];
 		$options['id']		= $data['form_slug'];
 		$options['value']	= html_entity_decode($data['value'], null, 'UTF-8');


### PR DESCRIPTION
This one I find really helpful. It adds an empty P tag to the WYSIWYG when you are creating a new item.

I found that some clients who are a little less savvy would just paste content right in, missing the opening and closing p tags. This would often cause a problem in my layouts and styles.

Now, there is a check to see if they just left empty tags, it is a little hacky but this makes sure the field is not going to return an empty P tag.