### PR TITLE
fix sending 304 not modified for large files that don't have a cached thumb in the cache folder

### DIFF
--- a/system/cms/modules/files/controllers/files_front.php
+++ b/system/cms/modules/files/controllers/files_front.php
@@ -227,7 +227,7 @@ class Files_front extends Public_Controller
 				$thumb_filename = $this->_path.$file->filename;
 			}
 		}
-
+		
 		if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
 			(strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) == $thumb_modified) && $expire )
 		{
@@ -244,7 +244,7 @@ class Files_front extends Public_Controller
 
 	public function large($id)
 	{
-		return $this->thumb($id, 0, 0);
+		return $this->thumb($id, null, null);
 	}
 
 	public function cloud_thumb($id = 0, $width = 75, $height = 50, $mode = 'fit')

--- a/system/cms/modules/files/controllers/files_front.php
+++ b/system/cms/modules/files/controllers/files_front.php
@@ -227,7 +227,8 @@ class Files_front extends Public_Controller
 				$thumb_filename = $this->_path.$file->filename;
 			}
 		}
-		else if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
+
+		if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
 			(strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) == $thumb_modified) && $expire )
 		{
 			// Send 304 back to browser if file has not beeb changed
@@ -243,7 +244,7 @@ class Files_front extends Public_Controller
 
 	public function large($id)
 	{
-		return $this->thumb($id, null, null);
+		return $this->thumb($id, 0, 0);
 	}
 
 	public function cloud_thumb($id = 0, $width = 75, $height = 50, $mode = 'fit')


### PR DESCRIPTION
solves #3427