### PR TITLE
streams storage is no longer gitignored

### DIFF
--- a/storage/streams/.gitignore
+++ b/storage/streams/.gitignore
@@ -1,2 +1,1 @@
-*
 !.gitignore


### PR DESCRIPTION
I think this should not be gitignored. When I create a new page type in the admin on my local environment, I want to be able to commit this in my git repository, just like on the 2.x branch