### PR TITLE
escape hyphen in preg_replace regexp, fixes #3454

### DIFF
--- a/system/cms/helpers/MY_inflector_helper.php
+++ b/system/cms/helpers/MY_inflector_helper.php
@@ -40,8 +40,8 @@ if(!function_exists('slugify'))
 	{	
 		$string = trim($string);
 		$string = strtolower($string);
-		$string = preg_replace('/[\s-]+/', $separator, $string);
-		$string = preg_replace("/[^0-9a-zA-Z-]/", '', $string);
+		$string = preg_replace('/[\s\-]+/', $separator, $string);
+		$string = preg_replace("/[^0-9a-zA-Z\-]/", '', $string);
 		
 		return $string;
 	}

--- a/system/cms/modules/pages/field_types/chunks/field.chunks.php
+++ b/system/cms/modules/pages/field_types/chunks/field.chunks.php
@@ -138,8 +138,8 @@ class Field_chunks
 			foreach ($chunks as $chunk)
 			{
 				$this->CI->page_chunk_m->insert(array(
-					'slug' 		=> preg_replace('/[^a-zA-Z0-9_-]/', '', $chunk->slug),
-					'class' 	=> preg_replace('/[^a-zA-Z0-9-_\s]/', '', $chunk->class),
+					'slug' 		=> preg_replace('/[^a-zA-Z0-9_\-]/', '', $chunk->slug),
+					'class' 	=> preg_replace('/[^a-zA-Z0-9\-_\s]/', '', $chunk->class),
 					'page_id' 	=> ci()->page_id,
 					'body' 		=> $chunk->body,
 					'parsed'	=> ($chunk->type == 'markdown') ? parse_markdown($chunk->body) : '',

--- a/system/cms/modules/pages/models/page_chunk_m.php
+++ b/system/cms/modules/pages/models/page_chunk_m.php
@@ -49,8 +49,8 @@ class Page_chunk_m extends MY_Model
 			foreach ($page->chunks as $chunk)
 			{
 				$this->insert(array(
-					'slug' 		=> preg_replace('/[^a-zA-Z0-9_-]/', '', $chunk->slug),
-					'class' 	=> preg_replace('/[^a-zA-Z0-9_-\s]/', '', $chunk->class),
+					'slug' 		=> preg_replace('/[^a-zA-Z0-9_\-]/', '', $chunk->slug),
+					'class' 	=> preg_replace('/[^a-zA-Z0-9_\-\s]/', '', $chunk->class),
 					'page_id' 	=> $input['page_id'],
 					'body' 		=> $chunk->body,
 					'parsed'	=> ($chunk->type == 'markdown') ? parse_markdown($chunk->body) : '',


### PR DESCRIPTION
This can be a serious issue. If you're upgrading from a pyro version that used chunks, you'll lose them the next time you click "save" in the page editor.

I've found a few other instances of this, not related to the chunks stuff, and fixed those to.
You could either move the hyphen to the end of expression or escape it - I like escaping stuff ^^

fixes #3454