### PR TITLE
add d() and dd() to twigbridge allowed list

### DIFF
--- a/config/twigbridge.php
+++ b/config/twigbridge.php
@@ -167,6 +167,12 @@ return [
         */
 
         'functions' => [
+            'd' => [
+                'is_safe' => ['html']
+            ],
+            'dd' => [
+                'is_safe' => ['html']
+            ],
             'elixir',
             'head', 
             'last',


### PR DESCRIPTION
not sure if is_safe is required?