### PR TITLE
Add separated `.env` setting for debug bar with fallback to APP_DEBUG

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -12,7 +12,7 @@ return [
      |
      */
 
-    'enabled' => env('APP_DEBUG', true),
+    'enabled' => env('DEBUG_BAR', env('APP_DEBUG', true)),
 
     /*
      |--------------------------------------------------------------------------


### PR DESCRIPTION
Actually I think that we have to replace that debug bar with some another. I'll write you about some later.