### PR TITLE
Remove unnecessary keys from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
         ]
     },
     "config": {
+        "bin-dir": "bin",
         "preferred-install": "dist"
     },
     "minimum-stability": "stable"

--- a/composer.json
+++ b/composer.json
@@ -102,9 +102,7 @@
             "tests/TestCase.php"
         ]
     },
-    "scripts": {},
     "config": {
-        "bin-dir": "bin",
         "preferred-install": "dist"
     },
     "minimum-stability": "stable"


### PR DESCRIPTION
We don't need to define an empty `scripts` key, and the `bin` directory (that was listed as a `bin-dir`) doesn't appear to exist at all.