### PR TITLE
Update contribution guidelines for PSR-2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,4 +37,3 @@ If you discover a security vulnerability within Pyro, please send an e-mail to R
 Pyro follows the PSR-4, PSR-2 and PSR-1 coding standards. In addition to these standards, the following coding standards should be followed:
 
 The class namespace declaration must be on the same line as <?php.
-Indent with tabs, align with spaces.


### PR DESCRIPTION
Based on commit 00ddd35c39b5c15ed44f0924bd1a321e329507d6 the line about using tabs is no longer relevant if conforming to PSR-2 standards.