### PR TITLE
composer.lock commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .env
 .coverage
-composer.lock
 /bin
 /core
 /build


### PR DESCRIPTION
Hello,
I think better practice is to commit composer.lock.
We will have 'tested, working' version of the Framework/CMS.

I think I can commit composer.lock too - if you want!