### PR TITLE
Fix "it's" and add missing comma

### DIFF
--- a/docs/en/04.configuration/03.streams-platform-configuration.md
+++ b/docs/en/04.configuration/03.streams-platform-configuration.md
@@ -4,7 +4,7 @@ title: Streams Platform Configuration
 
 ### Streams Platform Configuration
 
-The Streams Platform contains it's own configuration. You may easily access configuration values for the Streams Platform just the same as you would any other configuration. Configuration values for the Streams Platform have a `streams::` prefix:
+The Streams Platform contains its own configuration. You may easily access configuration values for the Streams Platform just the same as you would any other configuration. Configuration values for the Streams Platform have a `streams::` prefix:
 
     $value = config('streams::locales.default');
 
@@ -14,7 +14,7 @@ To set configuration values at runtime, pass an array to the `config` helper:
 
 #### Publishing streams configuration
 
-In order to configure the Streams Platform without modifying core files you will need to publish the Streams Platform with the following command:
+In order to configure the Streams Platform without modifying core files, you will need to publish the Streams Platform with the following command:
 
      php artisan streams:publish
 


### PR DESCRIPTION
- Possessive "it's" should not have an apostrophe (it's = it is)
- "In order to do X, Y must occur" needs a comma