### PR TITLE
Fixed broken tags.

### DIFF
--- a/docs/en/01.installation/01.index.md
+++ b/docs/en/01.installation/01.index.md
@@ -6,4 +6,7 @@ title: Installation
 
 This section will go over what you need to install PyroCMS and how to do it.
 
-<div class="alert alert-danger">**Heads Up:** Looking for documentation on developing with PyroCMS? Have a look at documentation for Pyro's engine, the [Streams Platform](/documentation/streams-platform).</div>
+<div class="alert alert-danger">
+  <strong>Heads Up:</strong> Looking for documentation on developing with PyroCMS? Have a look at the documentation for
+  Pyro's engine, the <a href="/documentation/streams-platform">Streams Platform</a>.
+</div>


### PR DESCRIPTION
Looked like Markdown code within the div tag were not being rendered as such.

![screenshot from 2018-07-08 09-53-01](https://user-images.githubusercontent.com/13920568/42418287-be210218-8294-11e8-9401-b8cc64d76f59.png)

So I thought: if the div tag could work, a good old anchor tag would work for the link, and a strong tag wouldn't go amiss for the intended bold text.
