### PR TITLE
Update 04.which-branch.md

### DIFF
--- a/docs/en/02.contributing/04.which-branch.md
+++ b/docs/en/02.contributing/04.which-branch.md
@@ -10,4 +10,4 @@ title: Which Branch?
 
 **Major** new features should always be sent to the `develop` branch, which contains upcoming releases.
 
-If you are unsure if your feature qualifies as a major or minor, please ask `ryanthompson` in the `#general` [PyroCMS Slack channel](https://pyrocms.slack.com/).
+If you are unsure if your feature qualifies as a major or minor, please ask `ryanthompson` in the `#pyro` [PyroCMS Slack channel](https://pyrocms.slack.com/).


### PR DESCRIPTION
There is no '#general' channel in the Slack channel anymore. Just #pyro and others.