### PR TITLE
Fix broken documentation markup

### DIFF
--- a/docs/en/01.installation/01.index.md
+++ b/docs/en/01.installation/01.index.md
@@ -6,4 +6,4 @@ title: Installation
 
 This section will go over what you need to install PyroCMS and how to do it.
 
-<div class="alert alert-danger">**Heads Up:** Looking for documentation on developing with PyroCMS? Have a look at documentation for Pyro's engine, the [Streams Platform](/documentation/streams-platform).</div>
+<div class="alert alert-danger"><strong>Heads Up:</strong> Looking for documentation on developing with PyroCMS? Have a look at documentation for Pyro's engine, the <a href="/documentation/streams-platform">Streams Platform</a>.</div>

--- a/docs/en/01.installation/03.server-configuration.md
+++ b/docs/en/01.installation/03.server-configuration.md
@@ -10,7 +10,7 @@ This section will go over a few basics of setting up your server for a Laravel a
 
 Below is an example NGINX configuration:
 
-<div class="alert alert-info">**Notice:** The web root should be set to your installation's **public** directory.</div>
+<div class="alert alert-info"><strong>Notice:</strong> The web root should be set to your installation's <strong>public</strong> directory.</div>
 
     # --------------------------
     #

--- a/docs/en/01.installation/04.installing-pyrocms.md
+++ b/docs/en/01.installation/04.installing-pyrocms.md
@@ -6,7 +6,7 @@ title: Installing PyroCMS
 
 PyroCMS utilizes [Composer](https://getcomposer.org/) to manage its dependencies. So, before using PyroCMS, make sure you have Composer installed on your machine.
 
-<div class="alert alert-danger">**Heads Up:** Do not create a .env file just yet - Pyro's installer will generate one for you.</div>
+<div class="alert alert-danger"><strong>Heads Up:</strong> Do not create a .env file just yet - Pyro's installer will generate one for you.</div>
 
 #### Via Installer
 
@@ -89,7 +89,7 @@ Then run the installer and indicate that the system is ready to install:
 
     php artisan install --ready
 
-<div class="alert alert-danger">**Heads Up!** The APP_KEY must be exactly 32 characters in length.</div>
+<div class="alert alert-danger"><strong>Heads Up!</strong> The APP_KEY must be exactly 32 characters in length.</div>
 
 ##### Using the cURL Installer
 

--- a/docs/en/02.contributing/02.bug-reports.md
+++ b/docs/en/02.contributing/02.bug-reports.md
@@ -10,7 +10,7 @@ However, if you file a bug report, your issue should contain a title and a clear
 
 Remember, bug reports are created in the hope that others with the same problem will be able to collaborate with you on solving it. Do not expect that the bug report will automatically see any activity or that others will jump to fix it. Creating a bug report serves to help yourself and others start on the path of fixing the problem you are experiencing.
 
-Please submit _all_ bug reports to the [[http://github.com/pyrocms/pyrocms](PyroCMS](https://github.com/pyrocms/pyrocms](PyroCMS) repository). All pull requests must be submitted to the applicable addon repository.
+Please submit _all_ bug reports to the [PyroCMS repository](http://github.com/pyrocms/pyrocms). All pull requests must be submitted to the applicable addon repository.
 
 When submitting bug reports for other addons to the PyroCMS repository please prefix the repository the bug report is for by prefixing it with the application addon.
 

--- a/docs/en/02.contributing/03.development-discussion.md
+++ b/docs/en/02.contributing/03.development-discussion.md
@@ -4,4 +4,4 @@ title: Development Discussion
 
 ### Development Discussion
 
-Discussion regarding bugs, new features, and implementation of existing features should take place on the [[http://pyrocms.com/forum](PyroCMS](http://pyrocms.com/forum](PyroCMS) forum). Discussion can also be had in the [PyroCMS Slack team](https://pyrocms.slack.com/). Ryan Thompson, the lead developer, is typically present in the channel on weekdays from 10am-4pm (UTC-06:00 or America/Chicago).
+Discussion regarding bugs, new features, and implementation of existing features should take place on the [PyroCMS Forum](http://pyrocms.com/forum). Discussion can also be had in the [PyroCMS Slack team](https://pyrocms.slack.com/). Ryan Thompson, the lead developer, is typically present in the channel on weekdays from 10am-4pm (UTC-06:00 or America/Chicago).

--- a/docs/en/02.contributing/04.which-branch.md
+++ b/docs/en/02.contributing/04.which-branch.md
@@ -4,7 +4,7 @@ title: Which Branch?
 
 ### Which Branch?
 
-*All **bug fixes should be sent to the latest stable branch. Bug fixes should** never** be sent to the `master` branch unless no develop branch exists for whatever reason.
+All bug fixes should be sent to the latest stable branch. Bug fixes should **never** be sent to the `master` branch unless no develop branch exists for whatever reason.
 
 **Minor** features that are **fully backwards compatible** with the current release may be sent to the latest stable branch.
 

--- a/docs/en/03.structure/02.the-addons-directory.md
+++ b/docs/en/03.structure/02.the-addons-directory.md
@@ -6,7 +6,7 @@ title: The Addons Directory
 
 The `addons` directory is where all addons not included in the composer.json file should be kept.
 
-<div class="alert alert-info">**Note:** Typically addons in the addons directory are committed to your project repository.</div>
+<div class="alert alert-info"><strong>Note:</strong> Typically addons in the addons directory are committed to your project repository.</div>
 
 #### Addon Directory Structure
 

--- a/docs/en/03.structure/06.the-core-directory.md
+++ b/docs/en/03.structure/06.the-core-directory.md
@@ -6,5 +6,5 @@ title: The Core Directory
 
 The `core` directory contains any addon required by your `composer.json` file. Any file contained in the `composer.json` dependencies is considered part of your website or application's core dependencies.
 
-<div class="alert alert-warning">**Warning:** It is not advised to commit your core directory!</div>
+<div class="alert alert-warning"><strong>Warning:</strong> It is not advised to commit your core directory!</div>
 

--- a/docs/en/03.structure/09.the-resource-directory.md
+++ b/docs/en/03.structure/09.the-resource-directory.md
@@ -8,7 +8,7 @@ The `resources` directory contains Laravel views as well as raw, un-compiled Lar
 
 While you can use the resources directory exactly like you would in a native Laravel application you are encouraged to bundle language files, assets, and views in their respective addons that you are developing for your website or application.
 
-<div class="alert alert-info">**Note:** It is highly encouraged to bundle your resources into their respective addons that you develop.</div>
+<div class="alert alert-info"><strong>Note:</strong> It is highly encouraged to bundle your resources into their respective addons that you develop.</div>
 
 The `resources` directory will also contain override files for addon config, views, and language files. You will be published to the `resources/{application}/addons` directory then when running the corresponding Artisan commands.
 

--- a/docs/en/03.structure/10.the-routes-directory.md
+++ b/docs/en/03.structure/10.the-routes-directory.md
@@ -6,7 +6,7 @@ title: The Routes Directory
 
 The routes directory contains all of the route definitions for your application. By default, three route files are included with Laravel: web.php, api.php, and console.php.
 
-<div class="alert alert-info">**Note:** It is highly encouraged to bundle your routes into their respective addons that you develop.</div>
+<div class="alert alert-info"><strong>Note:</strong> It is highly encouraged to bundle your routes into their respective addons that you develop.</div>
 
 The web.php file contains routes that the RouteServiceProvider places in the web middleware group, which provides session state, CSRF protection, and cookie encryption. If your application does not offer a stateless, RESTful API, all of your routes will most likely be defined in the web.php file.
 
@@ -14,4 +14,4 @@ The api.php file contains routes that the RouteServiceProvider places in the api
 
 The console.php file is where you may define all of your Closure based console commands. Each Closure is bound to a command instance allowing a simple approach to interacting with each command's IO methods. Even though this file does not define HTTP routes, it defines console based entry points (routes) into your application.
 
-<div class="alert alert-primary">**Pro Tip:** These routes are loaded FIRST. This means that duplicate subsequent routes will override them by name and route path.</div>
+<div class="alert alert-primary"><strong>Pro Tip:</strong> These routes are loaded FIRST. This means that duplicate subsequent routes will override them by name and route path.</div>

--- a/docs/en/04.configuration/01.index.md
+++ b/docs/en/04.configuration/01.index.md
@@ -4,4 +4,4 @@ title: Configuration
 
 ## Configuration
 
-This section will describe how configuration works in PyroCMS and how to access it. For the most part configuration in PyroCMS works exactly the same as [[https://laravel.com/docs/5.3/configuration](configuration](https://laravel.com/docs/5.3/configuration](configuration) in Laravel).
+This section will describe how configuration works in PyroCMS and how to access it. For the most part configuration in PyroCMS works exactly the same as (configuration in Laravel)[https://laravel.com/docs/5.5/configuration].

--- a/docs/en/05.errors-and-logging/03.custom-exceptions.md
+++ b/docs/en/05.errors-and-logging/03.custom-exceptions.md
@@ -30,4 +30,4 @@ Lastly you can define view overrides manually within your theme class by definin
         'streams::errors/500' => 'example.theme.test::custom/errors/500',
     ];
 
-<div class="alert alert primary">**Pro Tip:** You can override any view in the same fashion as above.</div>
+<div class="alert alert primary"><strong>Pro Tip:</strong> You can override any view in the same fashion as above.</div>


### PR DESCRIPTION
There are several places where the markup is showing as broken on the documentation site.
In some cases the links aren't rendering correctly at all.

I've also updated the link to the Laravel configuration docs to match the version of Laravel that Pyro is currently using.