### PR TITLE
ClassMap Package Version Updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
         "anomaly/html_block-extension": "~1.0.0",
         "anomaly/wysiwyg_block-extension": "~1.0.0",
         "pyrocms/starter-theme": "~1.0.0",
-        "pyrocms/accelerant-theme": "~1.2.0"
+        "pyrocms/accelerant-theme": "~1.2.0",
+        "symfony/class-loader": "3.3"
     },
     "require-dev": {
         "filp/whoops": "~2.0",


### PR DESCRIPTION
The ClassMapGenerator package has moved to the 6th tag and the dump function is no longer available. So I fixed it to 3.3. 
Reason for change: Installation error    Class "Composer\Autoload\ClassMapGenerator" not found  
